### PR TITLE
Parse unix_timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ nom = "7.1.3"
 nom-derive = "0.10.1"
 serde = { version = "1.0.166", features = ["derive"] }
 
+[features]
+default = []
+unix_timestamp = []
+
 [dev-dependencies]
 insta = { version = "1.30.0", features = ["yaml"] }
 serde_json = "1.0.100"

--- a/src/snapshots/netflow_parser__tests__it_parses_v5_timestamp.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v5_timestamp.snap
@@ -1,5 +1,6 @@
 ---
 source: src/lib.rs
+assertion_line: 263
 expression: "NetflowParser::default().parse_bytes(&packet)"
 ---
 - V5:
@@ -9,8 +10,9 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       sys_up_time:
         secs: 50332
         nanos: 672000000
-      unix_secs: 83887623
-      unix_nsecs: 134807553
+      unix_time:
+        secs: 83887623
+        nanos: 134807553
       flow_sequence: 33752069
       engine_type: 6
       engine_id: 7

--- a/src/snapshots/netflow_parser__tests__it_parses_v7.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v7.snap
@@ -9,12 +9,8 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       sys_up_time:
         secs: 50332
         nanos: 672000000
-      unix_secs:
-        secs: 83887623
-        nanos: 0
-      unix_nsecs:
-        secs: 0
-        nanos: 134807553
+      unix_secs: 83887623
+      unix_nsecs: 134807553
       flow_sequence: 33752069
       reserved: 101124105
     body:

--- a/src/snapshots/netflow_parser__tests__it_parses_v7_timestamp.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v7_timestamp.snap
@@ -1,20 +1,20 @@
 ---
 source: src/lib.rs
+assertion_line: 279
 expression: "NetflowParser::default().parse_bytes(&packet)"
 ---
-- V5:
+- V7:
     header:
-      version: 5
+      version: 7
       count: 512
       sys_up_time:
         secs: 50332
         nanos: 672000000
-      unix_secs: 83887623
-      unix_nsecs: 134807553
+      unix_time:
+        secs: 83887623
+        nanos: 134807553
       flow_sequence: 33752069
-      engine_type: 6
-      engine_id: 7
-      sampling_interval: 2057
+      reserved: 101124105
     body:
       src_addr: 0.1.2.3
       dst_addr: 4.5.6.7
@@ -31,7 +31,7 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         nanos: 553000000
       src_port: 515
       dst_port: 1029
-      pad1: 6
+      flags_fields_valid: 6
       tcp_flags: 7
       protocol_number: 8
       protocol_type: EGP
@@ -40,5 +40,6 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       dst_as: 515
       src_mask: 4
       dst_mask: 5
-      pad2: 1543
+      flags_fields_invalid: 1543
+      router_src: 8.9.0.1
 

--- a/src/static_versions/v7.rs
+++ b/src/static_versions/v7.rs
@@ -7,6 +7,8 @@ use crate::protocol::ProtocolTypes;
 use crate::{NetflowByteParserStatic, NetflowPacketResult, ParsedNetflow};
 
 use nom::number::complete::be_u32;
+#[cfg(feature = "unix_timestamp")]
+use nom::number::complete::be_u64;
 use nom_derive::*;
 use serde::Serialize;
 use Nom;
@@ -42,12 +44,22 @@ pub struct Header {
     /// Current time in milliseconds since the export device booted
     #[nom(Map = "|i| Duration::from_millis(i.into())", Parse = "be_u32")]
     pub sys_up_time: Duration,
-    /// Current seconds since 0000 UTC 1970
-    #[nom(Map = "|i| Duration::from_secs(i.into())", Parse = "be_u32")]
-    pub unix_secs: Duration,
+
+    /// Current count since 0000 UTC 1970
+    #[cfg(feature = "unix_timestamp")]
+    #[nom(
+        Map = "|i| Duration::new((i >> 32) as u32 as u64, (i as u32))",
+        Parse = "be_u64"
+    )]
+    pub unix_time: Duration,
+
+    /// Current count of seconds since 0000 UTC 1970
+    #[cfg(not(feature = "unix_timestamp"))]
+    pub unix_secs: u32,
     /// Residual nanoseconds since 0000 UTC 1970
-    #[nom(Map = "|i| Duration::from_nanos(i.into())", Parse = "be_u32")]
-    pub unix_nsecs: Duration,
+    #[cfg(not(feature = "unix_timestamp"))]
+    pub unix_nsecs: u32,
+
     /// Sequence counter of total flows seen
     pub flow_sequence: u32,
     /// Unused (zero) bytes


### PR DESCRIPTION
Current implementation of parsing unix timestamp parts for `v5` and `v7` is inconvenient. It shows in test's `*.snap` files, that field `unix_secs` parses as `Duration` and `unix_nsecs` also as `Duration` and results looks like two incomplete `Duration` instances (first one has no nanoseconds, second one has no seconds). Thus user must merge them anyway to get correct value (you can find them in examples as `unix_secs`).

In my opinion, best reason to parse those values is construct complete `Duration` instance in the place, but it leads to changing in number and names if fields. Therefore I introduce `unix_timestamp` feature, that enables constructing `unix_time: Duration` on the fly, and fix original code to parse `unix_secs` and `unix_nsecs` as u32 values