### PR TITLE
Fix netflow v9 parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,6 @@ mod tests {
             },
         ];
         let template = V9Template {
-            length: 16,
             field_count: 2,
             template_id: 258,
             fields,
@@ -425,7 +424,6 @@ mod tests {
             0, 9, 0, 26, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 2, 0, 10, 0, 8, 0, 0, 1, 1,
         ];
         let template = V9Template {
-            length: 10,
             field_count: 2,
             template_id: 258,
             fields: vec![],

--- a/src/snapshots/netflow_parser__tests__it_parses_v9.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v9.snap
@@ -12,20 +12,20 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       source_id: 1
     flowsets:
       - flow_set_id: 0
-        template:
-          length: 16
-          template_id: 258
-          field_count: 2
-          fields:
-            - field_type_number: 1
-              field_type: InBytes
-              field_length: 4
-            - field_type_number: 8
-              field_type: Ipv4SrcAddr
-              field_length: 4
+        length: 16
+        templates:
+          - template_id: 258
+            field_count: 2
+            fields:
+              - field_type_number: 1
+                field_type: InBytes
+                field_length: 4
+              - field_type_number: 8
+                field_type: Ipv4SrcAddr
+                field_length: 4
       - flow_set_id: 258
+        length: 12
         data:
-          length: 12
           data_fields:
             - InBytes:
                 DataNumber: 151126788

--- a/src/snapshots/netflow_parser__tests__it_parses_v9_data_cached_template.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v9_data_cached_template.snap
@@ -12,8 +12,8 @@ expression: parser.parse_bytes(&packet)
       source_id: 1
     flowsets:
       - flow_set_id: 258
+        length: 12
         data:
-          length: 12
           data_fields:
             - InBytes:
                 DataNumber: 151126788

--- a/src/snapshots/netflow_parser__tests__it_parses_v9_many_flows.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v9_many_flows.snap
@@ -12,20 +12,20 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       source_id: 1
     flowsets:
       - flow_set_id: 0
-        template:
-          length: 16
-          template_id: 258
-          field_count: 2
-          fields:
-            - field_type_number: 1
-              field_type: InBytes
-              field_length: 4
-            - field_type_number: 8
-              field_type: Ipv4SrcAddr
-              field_length: 4
+        length: 16
+        templates:
+          - template_id: 258
+            field_count: 2
+            fields:
+              - field_type_number: 1
+                field_type: InBytes
+                field_length: 4
+              - field_type_number: 8
+                field_type: Ipv4SrcAddr
+                field_length: 4
       - flow_set_id: 258
+        length: 12
         data:
-          length: 12
           data_fields:
             - InBytes:
                 DataNumber: 151126788
@@ -35,4 +35,3 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
                 DataNumber: 151126788
               Ipv4SrcAddr:
                 Ip4Addr: 9.9.9.8
-

--- a/src/snapshots/netflow_parser__tests__it_parses_v9_options_template.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v9_options_template.snap
@@ -12,25 +12,25 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
       source_id: 1
     flowsets:
       - flow_set_id: 1
-        options_template:
-          length: 22
-          template_id: 275
-          options_scope_length: 4
-          options_length: 8
-          scope_fields:
-            - field_type_number: 2
-              field_type: Interface
-              field_length: 2
-          option_fields:
-            - field_type_number: 34
-              field_type: SamplingInterval
-              field_length: 2
-            - field_type_number: 36
-              field_type: FlowActiveTimeout
-              field_length: 1
+        length: 22
+        options_templates:
+          - template_id: 275
+            options_scope_length: 4
+            options_length: 8
+            scope_fields:
+              - field_type_number: 2
+                field_type: Interface
+                field_length: 2
+            option_fields:
+              - field_type_number: 34
+                field_type: SamplingInterval
+                field_length: 2
+              - field_type_number: 36
+                field_type: FlowActiveTimeout
+                field_length: 1
       - flow_set_id: 275
+        length: 9
         options_data:
-          length: 9
           scope_fields:
             - interface:
                 - 0

--- a/src/snapshots/netflow_parser__tests__it_parses_v9_with_no_template_fields_raises_error.snap
+++ b/src/snapshots/netflow_parser__tests__it_parses_v9_with_no_template_fields_raises_error.snap
@@ -2,33 +2,22 @@
 source: src/lib.rs
 expression: parser.parse_bytes(&packet)
 ---
-- Error:
-    error_message: Could not parse v9_packet
-    bytes:
-      - 0
-      - 9
-      - 0
-      - 26
-      - 0
-      - 0
-      - 0
-      - 1
-      - 0
-      - 0
-      - 0
-      - 1
-      - 0
-      - 0
-      - 0
-      - 0
-      - 1
-      - 2
-      - 0
-      - 10
-      - 0
-      - 8
-      - 0
-      - 0
-      - 1
-      - 1
+- V9:
+    header:
+      version: 9
+      count: 26
+      sys_up_time: 1
+      unix_secs: 1
+      sequence_number: 0
+      source_id: 16908298
+    flowsets:
+      - flow_set_id: 8
+        length: 0
+        unparsed_data:
+          - 0
+          - 8
+          - 0
+          - 0
+          - 1
+          - 1
 


### PR DESCRIPTION
V9 parser seems to not work correctly in some of the more complex cases. I improved parsing a bit:
1. Currently we parse and keep length of the Flowset in templates and data structures. I changed it to keep length in Flowset and pass it as arguments to other parsers if needed.
2. One of the reasons why this is needed, it is because we might have multiple templates in one Flowset. So apart from keeping length in Flowset, I changed the behavior of Template parsing. Now it is parsed as Vec<Template>.
3. In some cases when we receive Flowset with data but without template, parser returns an error that we could not parse v9 packet. It is not really useful result, because we still could parse headers and Flowset id. I added field unparsed_data to Flowset and put unparsed bytes there if we don't have templates. This way we still know that we could not fully parse packet, but at least we return headers and id, which seems to be more useful information.
4. With new way of handling v9 parsing, I also had to fix parse_flowsets() function to correctly decrease counter and skip unparsed bytes based on length of Flowset if needed.