### PR TITLE
V9 & Ipfix: Parse every flow record into a separate structure

### DIFF
--- a/src/netflow_common.rs
+++ b/src/netflow_common.rs
@@ -125,7 +125,7 @@ impl From<&V9> for NetflowCommon {
             if let V9FlowSetBody::Data(data) = &flowset.body {
                 for data_field in &data.fields {
                     let value_map: BTreeMap<V9Field, FieldValue> =
-                        data_field.values().cloned().collect();
+                        data_field.clone().into_iter().collect();
                     flowsets.push(NetflowCommonFlowSet {
                         src_addr: value_map
                             .get(&V9Field::Ipv4SrcAddr)
@@ -184,7 +184,7 @@ impl From<&IPFix> for NetflowCommon {
             if let IPFixFlowSetBody::Data(data) = &flowset.body {
                 for data_field in &data.fields {
                     let value_map: BTreeMap<IPFixField, FieldValue> =
-                        data_field.values().cloned().collect();
+                        data_field.clone().into_iter().collect();
                     flowsets.push(NetflowCommonFlowSet {
                         src_addr: value_map
                             .get(&IPFixField::IANA(IANAIPFixField::SourceIpv4address))
@@ -244,8 +244,6 @@ impl From<&IPFix> for NetflowCommon {
 
 #[cfg(test)]
 mod common_tests {
-
-    use std::collections::BTreeMap;
     use std::net::{IpAddr, Ipv4Addr};
 
     use crate::netflow_common::NetflowCommon;
@@ -409,66 +407,39 @@ mod common_tests {
                 },
                 body: V9FlowSetBody::Data(V9Data {
                     padding: vec![],
-                    fields: vec![BTreeMap::from([
+                    fields: vec![Vec::from([
                         (
-                            0,
-                            (
-                                V9Field::Ipv4SrcAddr,
-                                FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 1)),
-                            ),
+                            V9Field::Ipv4SrcAddr,
+                            FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 1)),
                         ),
                         (
-                            1,
-                            (
-                                V9Field::Ipv4DstAddr,
-                                FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 2)),
-                            ),
+                            V9Field::Ipv4DstAddr,
+                            FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 2)),
                         ),
                         (
-                            2,
-                            (
-                                V9Field::L4SrcPort,
-                                FieldValue::DataNumber(DataNumber::U16(1234)),
-                            ),
+                            V9Field::L4SrcPort,
+                            FieldValue::DataNumber(DataNumber::U16(1234)),
                         ),
                         (
-                            3,
-                            (
-                                V9Field::L4DstPort,
-                                FieldValue::DataNumber(DataNumber::U16(80)),
-                            ),
+                            V9Field::L4DstPort,
+                            FieldValue::DataNumber(DataNumber::U16(80)),
+                        ),
+                        (V9Field::Protocol, FieldValue::DataNumber(DataNumber::U8(6))),
+                        (
+                            V9Field::FirstSwitched,
+                            FieldValue::DataNumber(DataNumber::U32(100)),
                         ),
                         (
-                            4,
-                            (V9Field::Protocol, FieldValue::DataNumber(DataNumber::U8(6))),
+                            V9Field::LastSwitched,
+                            FieldValue::DataNumber(DataNumber::U32(200)),
                         ),
                         (
-                            5,
-                            (
-                                V9Field::FirstSwitched,
-                                FieldValue::DataNumber(DataNumber::U32(100)),
-                            ),
+                            V9Field::InSrcMac,
+                            FieldValue::MacAddr("00:00:00:00:00:01".to_string()),
                         ),
                         (
-                            6,
-                            (
-                                V9Field::LastSwitched,
-                                FieldValue::DataNumber(DataNumber::U32(200)),
-                            ),
-                        ),
-                        (
-                            7,
-                            (
-                                V9Field::InSrcMac,
-                                FieldValue::MacAddr("00:00:00:00:00:01".to_string()),
-                            ),
-                        ),
-                        (
-                            8,
-                            (
-                                V9Field::InDstMac,
-                                FieldValue::MacAddr("00:00:00:00:00:02".to_string()),
-                            ),
+                            V9Field::InDstMac,
+                            FieldValue::MacAddr("00:00:00:00:00:02".to_string()),
                         ),
                     ])],
                 }),
@@ -518,69 +489,42 @@ mod common_tests {
                     length: 0,
                 },
                 body: IPFixFlowSetBody::Data(IPFixData {
-                    fields: vec![BTreeMap::from([
+                    fields: vec![Vec::from([
                         (
-                            0,
-                            (
-                                IPFixField::IANA(IANAIPFixField::SourceIpv4address),
-                                FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 1)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::SourceIpv4address),
+                            FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 1)),
                         ),
                         (
-                            1,
-                            (
-                                IPFixField::IANA(IANAIPFixField::DestinationIpv4address),
-                                FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 2)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::DestinationIpv4address),
+                            FieldValue::Ip4Addr(Ipv4Addr::new(192, 168, 1, 2)),
                         ),
                         (
-                            2,
-                            (
-                                IPFixField::IANA(IANAIPFixField::SourceTransportPort),
-                                FieldValue::DataNumber(DataNumber::U16(1234)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::SourceTransportPort),
+                            FieldValue::DataNumber(DataNumber::U16(1234)),
                         ),
                         (
-                            3,
-                            (
-                                IPFixField::IANA(IANAIPFixField::DestinationTransportPort),
-                                FieldValue::DataNumber(DataNumber::U16(80)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::DestinationTransportPort),
+                            FieldValue::DataNumber(DataNumber::U16(80)),
                         ),
                         (
-                            4,
-                            (
-                                IPFixField::IANA(IANAIPFixField::ProtocolIdentifier),
-                                FieldValue::DataNumber(DataNumber::U8(6)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::ProtocolIdentifier),
+                            FieldValue::DataNumber(DataNumber::U8(6)),
                         ),
                         (
-                            5,
-                            (
-                                IPFixField::IANA(IANAIPFixField::FlowStartSysUpTime),
-                                FieldValue::DataNumber(DataNumber::U32(100)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::FlowStartSysUpTime),
+                            FieldValue::DataNumber(DataNumber::U32(100)),
                         ),
                         (
-                            6,
-                            (
-                                IPFixField::IANA(IANAIPFixField::FlowEndSysUpTime),
-                                FieldValue::DataNumber(DataNumber::U32(200)),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::FlowEndSysUpTime),
+                            FieldValue::DataNumber(DataNumber::U32(200)),
                         ),
                         (
-                            7,
-                            (
-                                IPFixField::IANA(IANAIPFixField::SourceMacaddress),
-                                FieldValue::MacAddr("00:00:00:00:00:01".to_string()),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::SourceMacaddress),
+                            FieldValue::MacAddr("00:00:00:00:00:01".to_string()),
                         ),
                         (
-                            8,
-                            (
-                                IPFixField::IANA(IANAIPFixField::DestinationMacaddress),
-                                FieldValue::MacAddr("00:00:00:00:00:02".to_string()),
-                            ),
+                            IPFixField::IANA(IANAIPFixField::DestinationMacaddress),
+                            FieldValue::MacAddr("00:00:00:00:00:02".to_string()),
                         ),
                     ])],
                 }),

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_0_length_fields_ipfix.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_0_length_fields_ipfix.snap
@@ -36,12 +36,9 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 1.2.3.4
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 1.2.3.4
-              - 2:
-                  - IANA: AssignedforNetFlowv9compatibility
+                - - IANA: AssignedforNetFlowv9compatibility
                   - Vec: []

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix.snap
@@ -36,21 +36,15 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 1.2.3.4
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 1.2.3.3
-              - 2:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 16909058
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 0.2.0.2
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 0.1.2.3
-              - 2:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 67438087

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_data_cached_template.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_data_cached_template.snap
@@ -16,9 +16,7 @@ expression: parser.parse_bytes(&packet)
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: PacketDeltaCount
+              - - - IANA: PacketDeltaCount
                   - DataNumber: 8
-              - 1:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 0.0.1.1

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_enterprise_bit_template_and_data.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_enterprise_bit_template_and_data.snap
@@ -204,175 +204,141 @@ expression: result
         body:
           Data:
             fields:
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.209.101.66
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.0.0.241
-              - 2:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12240
                   - Vec:
                       - 192
                       - 224
-              - 3:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 0
                       - 80
-              - 4:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 5:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 13
-              - 6:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 7:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12242
                   - Vec:
                       - 141
                       - 195
                       - 63
                       - 224
-              - 8:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 3
                       selector_id: 80
-              - 9:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 10
-              - 10:
-                  - IANA: SamplerId
+                - - IANA: SamplerId
                   - DataNumber: 9
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 13:
-                  - Cisco: CiscoAppHttpUriStatistics
+                - - Cisco: CiscoAppHttpUriStatistics
                   - String: "/DocLib1\u0000\u0000\u0001"
-              - 14:
-                  - Cisco: CiscoAppHttpHost
+                - - Cisco: CiscoAppHttpHost
                   - String: "\u0003\u0000\u0000P4\u0002portal.medsigroup.ru"
-              - 15:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 564191867
-              - 16:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 564303806
-              - 17:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 1
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 6208
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 15
-              - 22:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9303
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 23:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9292
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 24:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9300
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 25:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9319
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 26:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9316
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 27:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9268
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 28:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9313
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 29:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9306
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 30:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9307
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 31:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9309
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 32:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9273
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-              - 33:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 9272
                   - Vec:
                       - 0

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_mixed_enteprise_and_non_enterprise_fields.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_mixed_enteprise_and_non_enterprise_fields.snap
@@ -126,1139 +126,787 @@ expression: result
         body:
           Data:
             fields:
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.101.255.1
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.10.28.57
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 255
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 8
                       - 7
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 606
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 0
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 20
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387228
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019440532
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 53
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 192505
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 155
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 172.31.255.1
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.255.1
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 254
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 14
                       - 201
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387232
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019446788
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 120
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 2208
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 184
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.208.22.118
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.101.22.251
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 4
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 61
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 68
                       - 246
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387236
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019437108
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 59
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 96
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 6
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.0.151.220
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.101.151.95
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 60
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 223
                       - 251
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387306
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019447034
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 59
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 15264
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 24
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.101.22.251
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.25.22.18
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 126
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 19
                       - 137
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 4
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 20
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387310
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019446976
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 59
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 5872
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 367
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 224.0.0.5
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.255.1
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Ospfigp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 1
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 0
                       - 0
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 1
                       selector_id: 89
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 2
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 0
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387360
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019444662
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 80
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 23
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 0
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 0
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 172.31.254.101
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.254.101
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 48
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 255
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 14
                       - 201
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 0
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387474
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019447040
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 60
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 3816
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 318
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 224.0.0.5
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.250.252
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Ospfigp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 48
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 1
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 0
                       - 0
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 1
                       selector_id: 89
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 290
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 20
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 2
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 0
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387484
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019444636
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 0
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 7
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 0
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 0
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.208.22.13
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.101.22.251
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 4
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 61
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 68
                       - 246
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387486
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019437338
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 50
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 740
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 65
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 224.0.0.5
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.254.27
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Ospfigp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 48
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 1
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 0
                       - 0
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 1
                       selector_id: 89
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 2
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 0
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387494
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019443438
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 0
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 7
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 0
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 0
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.100.102.116
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.205.151.9
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 125
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 13
                       - 61
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 290
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 20
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 2
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 17
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387564
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019438730
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 239
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 225
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 8
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 96
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 8
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.208.22.124
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.101.22.251
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 4
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 61
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 68
                       - 246
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387592
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019437466
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 59
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 96
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 6
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 172.31.254.101
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.254.1
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 48
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 255
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 14
                       - 200
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 0
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387628
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019445566
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 60
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 552
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 23
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.1.22.47
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.101.22.251
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 8
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 61
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 68
                       - 246
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387640
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019437582
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 50
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 772
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 67
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 10.101.10.12
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 10.0.151.179
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Icmp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 60
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 0
                       - 0
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 479
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 2
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 4
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387662
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019446322
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 0
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 19
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 0
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 0
-              - 0:
-                  - Cisco: CiscoClientIpv4Address
+              - - - Cisco: CiscoClientIpv4Address
                   - Ip4Addr: 172.31.255.1
-              - 1:
-                  - Cisco: CiscoServerIpv4Address
+                - - Cisco: CiscoServerIpv4Address
                   - Ip4Addr: 172.31.254.101
-              - 2:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Udp
-              - 3:
-                  - IANA: IpDiffServCodePoint
+                - - IANA: IpDiffServCodePoint
                   - DataNumber: 0
-              - 4:
-                  - IANA: IpTtl
+                - - IANA: IpTtl
                   - DataNumber: 255
-              - 5:
-                  - Cisco:
+                - - Cisco:
                       Unknown: 12241
                   - Vec:
                       - 14
                       - 200
-              - 6:
-                  - IANA: IngressVrfid
+                - - IANA: IngressVrfid
                   - DataNumber: 0
-              - 7:
-                  - IANA: ApplicationId
+                - - IANA: ApplicationId
                   - ApplicationId:
                       classification_engine_id: 13
                       selector_id: 1
-              - 8:
-                  - IANA: VlanId
+                - - IANA: VlanId
                   - DataNumber: 0
-              - 9:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 10:
-                  - IANA: BiflowDirection
+                - - IANA: BiflowDirection
                   - DataNumber: 1
-              - 11:
-                  - Cisco: CiscoServicesWaasSegment
+                - - Cisco: CiscoServicesWaasSegment
                   - DataNumber: 16
-              - 12:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 0
-              - 13:
-                  - Cisco: CiscoServicesWaasPassthroughReason
+                - - Cisco: CiscoServicesWaasPassthroughReason
                   - DataNumber: 0
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 4019387700
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 4019446700
-              - 16:
-                  - IANA: NewConnectionDeltaCount
+                - - IANA: NewConnectionDeltaCount
                   - DataNumber: 0
-              - 17:
-                  - IANA: ConnectionSumDurationSeconds
+                - - IANA: ConnectionSumDurationSeconds
                   - DataNumber: 59
-              - 18:
-                  - IANA: ResponderOctets
+                - - IANA: ResponderOctets
                   - DataNumber: 0
-              - 19:
-                  - IANA: ResponderPackets
+                - - IANA: ResponderPackets
                   - DataNumber: 0
-              - 20:
-                  - IANA: InitiatorOctets
+                - - IANA: InitiatorOctets
                   - DataNumber: 1632
-              - 21:
-                  - IANA: InitiatorPackets
+                - - IANA: InitiatorPackets
                   - DataNumber: 68

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_multiple_flow_records.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_multiple_flow_records.snap
@@ -16,20 +16,15 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - Netscaler: NetscalerLicenseType
+                - - Netscaler: NetscalerLicenseType
                   - DataNumber: 1
-              - 3:
-                  - Netscaler: NetscalerMaxLicenseCount
+                - - Netscaler: NetscalerMaxLicenseCount
                   - DataNumber: 5
-              - 4:
-                  - Netscaler: NetscalerCurrentLicenseConsumed
+                - - Netscaler: NetscalerCurrentLicenseConsumed
                   - DataNumber: 0
       - header:
           header_id: 258
@@ -37,84 +32,59 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 3
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 817
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 838403000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 849399000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -132,120 +102,83 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "/vpn/index.html\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "GET\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "int-app-netscaler-10-1-ext.lab2.net\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:32.0) Gecko/20100101 Firefox/32.0\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 1
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 40
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 16
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 853386000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 853386000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -263,41 +196,29 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
       - header:
           header_id: 257
@@ -305,78 +226,55 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040954
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 443
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 51612
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 7
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 6917
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 1090527232
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 838403000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 850391000
-              - 18:
-                  - Netscaler: NetscalerRoundTripTime
+                - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 3
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 20:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 2147483651
-              - 21:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 22:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -394,8 +292,7 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 23:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
       - header:
           header_id: 258
@@ -403,84 +300,59 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 1
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 482
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -498,120 +370,83 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "/vpn/images/caxtonstyle.css\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "https://int-app-netscaler-10-1-ext.lab2.net/vpn/index.html\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "GET\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "int-app-netscaler-10-1-ext.lab2.net\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:32.0) Gecko/20100101 Firefox/32.0\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 3
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 120
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 16
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 886381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 889368000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -629,41 +464,29 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
       - header:
           header_id: 257
@@ -671,78 +494,55 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040954
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 443
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 51612
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 15
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 21968
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 1093672960
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 886381000
-              - 18:
-                  - Netscaler: NetscalerRoundTripTime
+                - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 2
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 20:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 2147483651
-              - 21:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 22:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -760,6 +560,5 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 23:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_options_template_with_data.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_options_template_with_data.snap
@@ -38,29 +38,23 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           OptionsData:
             fields:
-              - 0:
-                  - Enterprise: 123
+              - - - Enterprise: 123
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 1
-              - 1:
-                  - IANA: ExportedMessageTotalCount
+                - - IANA: ExportedMessageTotalCount
                   - DataNumber: 276
-              - 2:
-                  - IANA: ExportedFlowRecordTotalCount
+                - - IANA: ExportedFlowRecordTotalCount
                   - DataNumber: 5140
-              - 0:
-                  - Enterprise: 123
+              - - - Enterprise: 123
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 2
-              - 1:
-                  - IANA: ExportedMessageTotalCount
+                - - IANA: ExportedMessageTotalCount
                   - DataNumber: 5140
-              - 2:
-                  - IANA: ExportedFlowRecordTotalCount
+                - - IANA: ExportedFlowRecordTotalCount
                   - DataNumber: 7710

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_scappy_example.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_scappy_example.snap
@@ -124,76 +124,53 @@ expression: result
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 70.1.115.1
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 50.0.71.1
-              - 2:
-                  - IANA: IpClassOfService
+                - - IANA: IpClassOfService
                   - DataNumber: 0
-              - 3:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Anydistributedprotocol
-              - 4:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 0
-              - 5:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 0
-              - 6:
-                  - IANA: IcmpTypeCodeIpv4
+                - - IANA: IcmpTypeCodeIpv4
                   - DataNumber: 0
-              - 7:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 827
-              - 8:
-                  - IANA: BgpSourceAsNumber
+                - - IANA: BgpSourceAsNumber
                   - DataNumber: 2
-              - 9:
-                  - IANA: BgpDestinationAsNumber
+                - - IANA: BgpDestinationAsNumber
                   - DataNumber: 3
-              - 10:
-                  - IANA: BgpNextHopIpv4address
+                - - IANA: BgpNextHopIpv4address
                   - Ip4Addr: 204.42.110.101
-              - 11:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 854
-              - 12:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 1312
-              - 13:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 9
-              - 14:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 3019441902
-              - 15:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 3019616060
-              - 16:
-                  - IANA: IpNextHopIpv4address
+                - - IANA: IpNextHopIpv4address
                   - Ip4Addr: 204.42.110.189
-              - 17:
-                  - IANA: SourceIpv4prefixLength
+                - - IANA: SourceIpv4prefixLength
                   - DataNumber: 24
-              - 18:
-                  - IANA: DestinationIpv4prefixLength
+                - - IANA: DestinationIpv4prefixLength
                   - DataNumber: 24
-              - 19:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 0
-              - 20:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 21:
-                  - IANA: FlowStartMilliseconds
+                - - IANA: FlowStartMilliseconds
                   - Duration:
                       secs: 1480449931
                       nanos: 519000000
-              - 22:
-                  - IANA: FlowEndMilliseconds
+                - - IANA: FlowEndMilliseconds
                   - Duration:
                       secs: 1480450105
                       nanos: 677000000

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_template_of_first_flowset_unknown.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_template_of_first_flowset_unknown.snap
@@ -46,84 +46,59 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 3
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 817
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 838403000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 849399000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -141,120 +116,83 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "/vpn/index.html\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "GET\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "int-app-netscaler-10-1-ext.lab2.net\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:32.0) Gecko/20100101 Firefox/32.0\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 1
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 40
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 16
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 853386000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 853386000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -272,41 +210,29 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
       - header:
           header_id: 257
@@ -314,78 +240,55 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040954
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94120
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 443
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 51612
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 7
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 6917
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 1090527232
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 838403000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 850391000
-              - 18:
-                  - Netscaler: NetscalerRoundTripTime
+                - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 3
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 20:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 2147483651
-              - 21:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 22:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -403,8 +306,7 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 173
                       - 11
                       - 0
-              - 23:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
       - header:
           header_id: 258
@@ -412,84 +314,59 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 1
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 482
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -507,120 +384,83 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "/vpn/images/caxtonstyle.css\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "https://int-app-netscaler-10-1-ext.lab2.net/vpn/index.html\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "GET\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "int-app-netscaler-10-1-ext.lab2.net\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:32.0) Gecko/20100101 Firefox/32.0\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040953
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 51612
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 443
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 3
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 120
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 16
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 84025344
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 886381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 889368000
-              - 18:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 1
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 2147483651
-              - 20:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 21:
-                  - Netscaler: NetscalerAppUnitNameAppId
+                - - Netscaler: NetscalerAppUnitNameAppId
                   - DataNumber: 0
-              - 22:
-                  - Netscaler: NetscalerHttpResForwFB
+                - - Netscaler: NetscalerHttpResForwFB
                   - DataNumber: 0
-              - 23:
-                  - Netscaler: NetscalerHttpResForwLB
+                - - Netscaler: NetscalerHttpResForwLB
                   - DataNumber: 0
-              - 24:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -638,41 +478,29 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 25:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1
-              - 26:
-                  - Netscaler: NetscalerHttpReqUrl
+                - - Netscaler: NetscalerHttpReqUrl
                   - String: "\u0000"
-              - 27:
-                  - Netscaler: NetscalerHttpReqCookie
+                - - Netscaler: NetscalerHttpReqCookie
                   - String: "\u0000"
-              - 28:
-                  - Netscaler: NetscalerHttpReqReferer
+                - - Netscaler: NetscalerHttpReqReferer
                   - String: "\u0000"
-              - 29:
-                  - Netscaler: NetscalerHttpReqMethod
+                - - Netscaler: NetscalerHttpReqMethod
                   - String: "\u0000"
-              - 30:
-                  - Netscaler: NetscalerHttpReqHost
+                - - Netscaler: NetscalerHttpReqHost
                   - String: "\u0000"
-              - 31:
-                  - Netscaler: NetscalerHttpReqUserAgent
+                - - Netscaler: NetscalerHttpReqUserAgent
                   - String: "\u0000"
-              - 32:
-                  - Netscaler: NetscalerHttpContentType
+                - - Netscaler: NetscalerHttpContentType
                   - String: "\u0000"
-              - 33:
-                  - Netscaler: NetscalerHttpReqAuthorization
+                - - Netscaler: NetscalerHttpReqAuthorization
                   - String: "\u0000"
-              - 34:
-                  - Netscaler: NetscalerHttpReqVia
+                - - Netscaler: NetscalerHttpReqVia
                   - String: "\u0000"
-              - 35:
-                  - Netscaler: NetscalerHttpReqXForwardedFor
+                - - Netscaler: NetscalerHttpReqXForwardedFor
                   - String: "\u0000"
-              - 36:
-                  - Netscaler: NetscalerAaaUsername
+                - - Netscaler: NetscalerAaaUsername
                   - String: "\u0000"
       - header:
           header_id: 257
@@ -680,78 +508,55 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: ObservationPointId
+              - - - IANA: ObservationPointId
                   - DataNumber: 8731347
-              - 1:
-                  - IANA: ExportingProcessId
+                - - IANA: ExportingProcessId
                   - DataNumber: 0
-              - 2:
-                  - IANA: FlowId
+                - - IANA: FlowId
                   - DataNumber: 2040954
-              - 3:
-                  - Netscaler: NetscalerTransactionId
+                - - Netscaler: NetscalerTransactionId
                   - DataNumber: 94121
-              - 4:
-                  - Netscaler: NetscalerConnectionId
+                - - Netscaler: NetscalerConnectionId
                   - DataNumber: 2040953
-              - 5:
-                  - IANA: IpVersion
+                - - IANA: IpVersion
                   - DataNumber: 4
-              - 6:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 7:
-                  - IANA: PaddingOctets
+                - - IANA: PaddingOctets
                   - String: "\u0000\u0000"
-              - 8:
-                  - IANA: SourceIpv4address
+                - - IANA: SourceIpv4address
                   - Ip4Addr: 172.18.159.99
-              - 9:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 172.18.129.61
-              - 10:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 443
-              - 11:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 51612
-              - 12:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 15
-              - 13:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 21968
-              - 14:
-                  - IANA: TcpControlBits
+                - - IANA: TcpControlBits
                   - DataNumber: 24
-              - 15:
-                  - Netscaler: NetscalerFlowFlags
+                - - Netscaler: NetscalerFlowFlags
                   - DataNumber: 1093672960
-              - 16:
-                  - IANA: FlowStartMicroseconds
+                - - IANA: FlowStartMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 884381000
-              - 17:
-                  - IANA: FlowEndMicroseconds
+                - - IANA: FlowEndMicroseconds
                   - Duration:
                       secs: 15552744373216
                       nanos: 886381000
-              - 18:
-                  - Netscaler: NetscalerRoundTripTime
+                - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 2
-              - 19:
-                  - IANA: EgressInterface
+                - - IANA: EgressInterface
                   - DataNumber: 1
-              - 20:
-                  - IANA: IngressInterface
+                - - IANA: IngressInterface
                   - DataNumber: 2147483651
-              - 21:
-                  - Netscaler: NetscalerAppNameAppId
+                - - Netscaler: NetscalerAppNameAppId
                   - DataNumber: 9510
-              - 22:
-                  - Netscaler: NetscalerConnectionChainID
+                - - Netscaler: NetscalerConnectionChainID
                   - Vec:
                       - 0
                       - 80
@@ -769,6 +574,5 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                       - 54
                       - 12
                       - 0
-              - 23:
-                  - Netscaler: NetscalerConnectionChainHopCount
+                - - Netscaler: NetscalerConnectionChainHopCount
                   - DataNumber: 1

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_with_v9_options_template_packet.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_with_v9_options_template_packet.snap
@@ -84,30 +84,21 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 70.70.1.1
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 120.120.1.1
-              - 2:
-                  - IANA: SourceTransportPort
+                - - IANA: SourceTransportPort
                   - DataNumber: 12345
-              - 3:
-                  - IANA: DestinationTransportPort
+                - - IANA: DestinationTransportPort
                   - DataNumber: 32777
-              - 4:
-                  - IANA: ProtocolIdentifier
+                - - IANA: ProtocolIdentifier
                   - ProtocolType: Tcp
-              - 5:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 100
-              - 6:
-                  - IANA: OctetDeltaCount
+                - - IANA: OctetDeltaCount
                   - DataNumber: 125000000
-              - 7:
-                  - IANA: FlowStartSysUpTime
+                - - IANA: FlowStartSysUpTime
                   - DataNumber: 1744871721
-              - 8:
-                  - IANA: FlowEndSysUpTime
+                - - IANA: FlowEndSysUpTime
                   - DataNumber: 1744871721

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_multiple_packets.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_multiple_packets.snap
@@ -32,11 +32,9 @@ expression: "NetflowParser::default().parse_bytes(&all)"
         body:
           Data:
             fields:
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8
 - V5:
     header:
@@ -133,11 +131,9 @@ expression: "NetflowParser::default().parse_bytes(&all)"
         body:
           Data:
             fields:
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8
 - IPFix:
     header:
@@ -173,23 +169,17 @@ expression: "NetflowParser::default().parse_bytes(&all)"
         body:
           Data:
             fields:
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 1.2.3.4
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 1.2.3.3
-              - 2:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 16909058
-              - 0:
-                  - IANA: SourceIpv4address
+              - - - IANA: SourceIpv4address
                   - Ip4Addr: 0.2.0.2
-              - 1:
-                  - IANA: DestinationIpv4address
+                - - IANA: DestinationIpv4address
                   - Ip4Addr: 0.1.2.3
-              - 2:
-                  - IANA: PacketDeltaCount
+                - - IANA: PacketDeltaCount
                   - DataNumber: 67438087
 - V5:
     header:

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9.snap
@@ -32,9 +32,7 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_data_cached_template.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_data_cached_template.snap
@@ -17,9 +17,7 @@ expression: parser.parse_bytes(&packet)
         body:
           Data:
             fields:
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_ipv6flowlabel.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_ipv6flowlabel.snap
@@ -287,135 +287,101 @@ expression: "NetflowParser::default().parse_bytes(&packets)"
         body:
           Data:
             fields:
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 192.168.18.10
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 141.24.12.2
-                2:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 0.0.0.0
-                3:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 49856
-                4:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 53
-                5:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 2
-                6:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                7:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                8:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                9:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 1
-                10:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 82
-                11:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 10690
                       nanos: 167000000
-                12:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 10690
                       nanos: 167000000
-                13:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                14:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                15:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 8
                       - 0
-                16:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 192.168.18.10
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 141.24.12.2
-                2:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 0.0.0.0
-                3:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 40483
-                4:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 53
-                5:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 2
-                6:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                7:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                8:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                9:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 1
-                10:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 82
-                11:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 10688
                       nanos: 891000000
-                12:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 10688
                       nanos: 891000000
-                13:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                14:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                15:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 8
                       - 0
-                16:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
       - header:
           flowset_id: 262
@@ -423,77 +389,57 @@ expression: "NetflowParser::default().parse_bytes(&packets)"
         body:
           Data:
             fields:
-              - 0:
-                  - Ipv6SrcAddr
+              - - - Ipv6SrcAddr
                   - Ip6Addr: "fd01:8::2a20:235f:1f7b:9379"
-                1:
-                  - Ipv6DstAddr
+                - - Ipv6DstAddr
                   - Ip6Addr: "fd00::b2f2:8ff:fe20:1180"
-                2:
-                  - Ipv6NextHop
+                - - Ipv6NextHop
                   - Ip6Addr: "::"
-                3:
-                  - Ipv6FlowLabel
+                - - Ipv6FlowLabel
                   - DataNumber: 128630
-                4:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 58037
-                5:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 53
-                6:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 0
-                7:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 2
-                8:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                10:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 0
                       - 0
                       - 0
                       - 0
-                11:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 1
-                12:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 102
-                13:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 10688
                       nanos: 891000000
-                14:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 10688
                       nanos: 891000000
-                15:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                16:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                17:
-                  - InDstMac
+                - - InDstMac
                   - MacAddr: "10:90:27:E0:43:6D"
-                18:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 134
                       - 221
-                19:
-                  - Direction
+                - - Direction
                   - DataNumber: 1

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_many_flows.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_many_flows.snap
@@ -32,15 +32,11 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8
-              - 0:
-                  - InBytes
+              - - - InBytes
                   - DataNumber: 151126788
-                1:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 9.9.9.8

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_template_and_data_packet.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_template_and_data_packet.snap
@@ -278,164 +278,116 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - Ipv6SrcAddr
+              - - - Ipv6SrcAddr
                   - Ip6Addr: "2003:d1:ef3b:2200:fe34:97ff:feb7:686e"
-                1:
-                  - Ipv6DstAddr
+                - - Ipv6DstAddr
                   - Ip6Addr: "2606:4700:3032::6815:5338"
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 5
                       nanos: 637000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 42
                       nanos: 8000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 1215
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 9
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 58068
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 443
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 25
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 6
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv6SrcAddr
+              - - - Ipv6SrcAddr
                   - Ip6Addr: "2606:4700:3032::6815:5338"
-                1:
-                  - Ipv6DstAddr
+                - - Ipv6DstAddr
                   - Ip6Addr: "2003:d1:ef3b:2200:fe34:97ff:feb7:686e"
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 5
                       nanos: 637000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 42
                       nanos: 8000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 180
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 3
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 443
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 58068
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 4
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 6
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv6SrcAddr
+              - - - Ipv6SrcAddr
                   - Ip6Addr: "::1"
-                1:
-                  - Ipv6DstAddr
+                - - Ipv6DstAddr
                   - Ip6Addr: "::1"
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 20
                       nanos: 268000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 20
                       nanos: 268000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 60
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 1
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 8081
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 43754
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 20
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 6
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
       - header:
           flowset_id: 1024
@@ -443,321 +395,225 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 157.240.251.61
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 192.168.1.215
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 25
                       nanos: 352000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 30
                       nanos: 421000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2930
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 24
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 5222
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 44112
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 26
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 192.168.1.215
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 157.240.251.61
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 25
                       nanos: 352000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 30
                       nanos: 421000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 3639
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 33
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 44112
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 5222
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 30
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 93.209.14.73
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 157.240.251.61
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 25
                       nanos: 352000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 30
                       nanos: 422000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 1213
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 11
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 44112
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 5222
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 30
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 157.240.251.61
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 93.209.14.73
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 25
                       nanos: 352000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 30
                       nanos: 422000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 1465
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 12
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 5222
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 44112
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 26
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 192.168.1.37
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 198.252.206.25
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 43
                       nanos: 288000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 43
                       nanos: 469000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 635
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 9
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 41796
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 443
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 25
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-              - 0:
-                  - Ipv4SrcAddr
+              - - - Ipv4SrcAddr
                   - Ip4Addr: 198.252.206.25
-                1:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 192.168.1.37
-                2:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 43
                       nanos: 288000000
-                3:
-                  - LastSwitched
+                - - LastSwitched
                   - Duration:
                       secs: 43
                       nanos: 469000000
-                4:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 264
-                5:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 6
-                6:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 0
-                7:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 0
-                8:
-                  - Direction
+                - - Direction
                   - DataNumber: 1
-                9:
-                  - Unknown
+                - - Unknown
                   - Vec:
                       - 3
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 443
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 41796
-                12:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                13:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 21
-                14:
-                  - IpProtocolVersion
+                - - IpProtocolVersion
                   - DataNumber: 4
-                15:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_with_multiple_options_data.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_v9_with_multiple_options_data.snap
@@ -190,685 +190,475 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 22469
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.87
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.103
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 3768
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 4793
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 54
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.36
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 28
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 5
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 22
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 192
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 23
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 11511
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.42
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.190
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 52628
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 20901
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 242
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.9
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 7
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 9
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 17
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 94
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 119
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 50221
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.98
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.10
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 28924
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 37242
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 183
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.85
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 12
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 22
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 17
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 69
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 182
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 17000
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.29
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.217
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 54019
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 31892
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 135
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.54
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 18
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 20
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 24
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 3
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 3
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 3836
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.9
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.62
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 24247
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 57095
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 35
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.40
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 21
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 29
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 4
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 46
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 62
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 62314
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.46
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.149
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 17989
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 51448
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 95
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.89
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 4
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 12
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 193
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 20
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 14336
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.45
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.145
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 31952
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 34224
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 139
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.62
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 19
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 28
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 16
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 70
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 184
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 18757
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.27
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.196
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 30703
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 35045
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 154
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.69
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 29
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 2
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 16
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 62
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 163
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 33913
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.58
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.183
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 47159
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 51444
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 95
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.89
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 4
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 12
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 194
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 6
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 7454
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.17
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.122
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 45231
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 54318
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 122
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.56
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 17
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 21
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 17
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 76
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 127
       - header:
           flowset_id: 256
@@ -876,685 +666,475 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 68548
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.17
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.126
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 35973
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 38493
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 184
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.79
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 10
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 28
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 16
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 66
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 198
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 2470
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.4
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.25
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 36432
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 37072
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 178
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.84
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 14
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 17
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 2
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 142
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 175
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 29252
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.64
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.229
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 33344
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 33832
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 143
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.57
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 21
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 26
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 26
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 107
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 120
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 50925
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.100
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.2
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 2362
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 6644
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 42
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.50
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 15
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 15
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 2
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 102
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 106
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 41046
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.61
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.175
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 12773
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 21100
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 247
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.11
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 5
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 15
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 2
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 103
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 110
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 44693
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.75
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.193
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 23774
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 58643
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 41
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.48
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 17
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 17
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 172
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 85
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 54633
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.86
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.106
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 17988
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 51476
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 95
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.88
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 4
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 12
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 190
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 17
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 17657
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.31
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.208
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 47983
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 49960
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 79
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.82
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 13
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 18
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 152
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 51
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 59060
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.30
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.222
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 60658
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 12666
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 83
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.96
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 3
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 4
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 26
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 146
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 161
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 26110
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.98
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.11
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 26239
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 43420
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 253
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.3
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 1
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 3
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 16
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 90
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 116
       - header:
           flowset_id: 256
@@ -1562,685 +1142,475 @@ expression: "NetflowParser::default().parse_bytes(&packet)"
         body:
           Data:
             fields:
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 56498
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.78
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.76
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 44126
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 62559
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 27
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.18
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 14
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 18
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 194
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 19
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 13191
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.49
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.132
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 48550
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 49043
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 67
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.77
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 9
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 25
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 26
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 104
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 112
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 43491
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.70
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.214
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 37816
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 48033
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 199
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.29
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 26
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 12
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 157
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 71
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 70685
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.22
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.88
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Udp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 18684
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 55554
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 109
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.72
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 26
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 12
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 27
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 161
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 69
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 73882
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.4
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.25
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 35379
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 39960
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 167
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.91
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 6
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 9
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 17
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 78
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 136
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 73548
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.11
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.45
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 43210
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 64423
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 2
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.3
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 1
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 3
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 16
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 82
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 147
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 61275
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.34
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.250
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 0
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 15333
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 19513
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 212
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.50
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 16
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 16
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 2
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 130
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 185
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 18094
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.27
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.205
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 160
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 3850
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 4881
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 55
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.35
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 28
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 7
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 22
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 167
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 99
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 38963
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.54
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.136
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Tcp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 16
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 64029
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 1348
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 13
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.9
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 7
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 9
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 17
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 95
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 108
-              - 0:
-                  - LastSwitched
+              - - - LastSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 376000000
-                1:
-                  - FirstSwitched
+                - - FirstSwitched
                   - Duration:
                       secs: 3488219
                       nanos: 284000000
-                2:
-                  - InBytes
+                - - InBytes
                   - DataNumber: 2003
-                3:
-                  - InPkts
+                - - InPkts
                   - DataNumber: 47659
-                4:
-                  - InputSnmp
+                - - InputSnmp
                   - DataNumber: 4
-                5:
-                  - OutputSnmp
+                - - OutputSnmp
                   - DataNumber: 2
-                6:
-                  - Ipv4SrcAddr
+                - - Ipv4SrcAddr
                   - Ip4Addr: 10.0.0.63
-                7:
-                  - Ipv4DstAddr
+                - - Ipv4DstAddr
                   - Ip4Addr: 12.0.0.223
-                8:
-                  - Protocol
+                - - Protocol
                   - ProtocolType: Icmp
-                9:
-                  - SrcTos
+                - - SrcTos
                   - DataNumber: 192
-                10:
-                  - L4SrcPort
+                - - L4SrcPort
                   - DataNumber: 42544
-                11:
-                  - L4DstPort
+                - - L4DstPort
                   - DataNumber: 59214
-                12:
-                  - FlowSamplerId
+                - - FlowSamplerId
                   - DataNumber: 0
-                13:
-                  - Vendor
+                - - Vendor
                   - Vec:
                       - 58
-                14:
-                  - Ipv4NextHop
+                - - Ipv4NextHop
                   - Ip4Addr: 10.0.0.32
-                15:
-                  - DstMask
+                - - DstMask
                   - DataNumber: 25
-                16:
-                  - SrcMask
+                - - SrcMask
                   - DataNumber: 13
-                17:
-                  - TcpFlags
+                - - TcpFlags
                   - DataNumber: 2
-                18:
-                  - Direction
+                - - Direction
                   - DataNumber: 0
-                19:
-                  - DstAs
+                - - DstAs
                   - DataNumber: 139
-                20:
-                  - SrcAs
+                - - SrcAs
                   - DataNumber: 168
       - header:
           flowset_id: 257


### PR DESCRIPTION
Parse every flow record into a separate structure instead of having only one field inside each btree