### PR TITLE
Ipfix dateTimeNanoseconds and dateTimeMicroseconds use the NTP 64 bit time format

### DIFF
--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_multiple_flow_records.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_multiple_flow_records.snap
@@ -66,12 +66,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 838403000
+                      secs: 3621155483
+                      nanos: 175000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 849399000
+                      secs: 3621155483
+                      nanos: 178000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -160,12 +160,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 853386000
+                      secs: 3621155483
+                      nanos: 179000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 853386000
+                      secs: 3621155483
+                      nanos: 179000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -260,12 +260,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 1090527232
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 838403000
+                      secs: 3621155483
+                      nanos: 175000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 850391000
+                      secs: 3621155483
+                      nanos: 178000
                 - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 3
                 - - IANA: EgressInterface
@@ -334,12 +334,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -428,12 +428,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 886381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 889368000
+                      secs: 3621155483
+                      nanos: 187000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -528,12 +528,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 1093672960
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 886381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 2
                 - - IANA: EgressInterface

--- a/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_template_of_first_flowset_unknown.snap
+++ b/src/snapshots/netflow_parser__tests__base_tests__it_parses_ipfix_template_of_first_flowset_unknown.snap
@@ -80,12 +80,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 838403000
+                      secs: 3621155483
+                      nanos: 175000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 849399000
+                      secs: 3621155483
+                      nanos: 178000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -174,12 +174,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 853386000
+                      secs: 3621155483
+                      nanos: 179000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 853386000
+                      secs: 3621155483
+                      nanos: 179000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -274,12 +274,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 1090527232
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 838403000
+                      secs: 3621155483
+                      nanos: 175000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 850391000
+                      secs: 3621155483
+                      nanos: 178000
                 - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 3
                 - - IANA: EgressInterface
@@ -348,12 +348,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -442,12 +442,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 84025344
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 886381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 889368000
+                      secs: 3621155483
+                      nanos: 187000
                 - - IANA: IngressInterface
                   - DataNumber: 1
                 - - IANA: EgressInterface
@@ -542,12 +542,12 @@ expression: "parser.parse_bytes(&hex::decode(hex2).unwrap())"
                   - DataNumber: 1093672960
                 - - IANA: FlowStartMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 884381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - IANA: FlowEndMicroseconds
                   - Duration:
-                      secs: 15552744373216
-                      nanos: 886381000
+                      secs: 3621155483
+                      nanos: 186000
                 - - Netscaler: NetscalerRoundTripTime
                   - DataNumber: 2
                 - - IANA: EgressInterface

--- a/src/variable_versions/data_number.rs
+++ b/src/variable_versions/data_number.rs
@@ -315,22 +315,18 @@ impl FieldValue {
                 )
             }
             FieldDataType::DurationMicros => {
-                let (i, data_number) = DataNumber::parse(remaining, field_length, false)?;
-                (
-                    i,
-                    FieldValue::Duration(Duration::from_micros(
-                        <DataNumber as Into<usize>>::into(data_number) as u64,
-                    )),
-                )
+                let (i, seconds) = u32::parse_be(remaining)?;
+                let (i, fraction) = u32::parse_be(i)?;
+                let dur = Duration::from_secs(seconds as u64)
+                    + Duration::from_micros((fraction as u64 * 1_000_000) >> 32);
+                (i, FieldValue::Duration(dur))
             }
             FieldDataType::DurationNanos => {
-                let (i, data_number) = DataNumber::parse(remaining, field_length, false)?;
-                (
-                    i,
-                    FieldValue::Duration(Duration::from_nanos(
-                        <DataNumber as Into<usize>>::into(data_number) as u64,
-                    )),
-                )
+                let (i, seconds) = u32::parse_be(remaining)?;
+                let (i, fraction) = u32::parse_be(i)?;
+                let dur = Duration::from_secs(seconds as u64)
+                    + Duration::from_nanos((fraction as u64 * 1_000_000_000) >> 32);
+                (i, FieldValue::Duration(dur))
             }
             FieldDataType::ProtocolType => {
                 let (i, protocol) = ProtocolTypes::parse(remaining)?;


### PR DESCRIPTION
Hey :).
The Ipfix dateTimeNanoseconds and dateTimeMicroseconds fields are specifed in the RFC.
According to the [RFC](https://datatracker.ietf.org/doc/html/rfc7011#section-6.1.9), both fields use the NTP 64 bit time format encoding. Hence, just parsing them as integers and calling `from_micros` or `from_nanos` is wrong.

Best regards
Moritz