### PR TITLE
fix: TemplateStore eviction cleanup, error reporting, and doc accurac…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netflow_parser"
 description = "Parser for Netflow Cisco V5, V7, V9, IPFIX"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Michael Mileusnich <michael.mileusnich@gmail.com>"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,76 @@
+# 1.0.4
+
+## Fixes
+
+* **`TemplateStore`: source-eviction in `AutoScopedParser` no longer leaks
+  store entries.** When `max_sources` capacity was reached and a per-source
+  parser was popped from the LRU, every template that source had written
+  under its scope (e.g. `v9:10.0.0.1:2055/0`) was orphaned in the store
+  forever. `evict_global_lru` now calls `clear_v9_templates` /
+  `clear_ipfix_templates` on the evicted parser before dropping it, so the
+  external store keyspace tracks the live source set.
+
+* **`TemplateStore`: `clear_v9_templates` / `clear_ipfix_templates` now record
+  backend errors.** Previously these methods called `let _ = store.remove(...)`,
+  silently swallowing failures. They now bump
+  `template_store_backend_errors` on each failed `remove`, matching every
+  other store call site.
+
+* **`TemplateStore`: misleading inline doc comment on `clear_*_templates`
+  removed.** The comment claimed that after a clear, "subsequent reads do
+  not transparently repopulate the in-process cache via read-through" — true
+  only for templates that were in the in-process LRU at clear time. Templates
+  evicted from the LRU before the call, or written by another parser instance
+  under the same scope, remain reachable via read-through. The trait
+  intentionally exposes only `get`/`put`/`remove`, not a per-scope wipe; the
+  comment now documents this honestly.
+
+* **`set_template_store_scope` rustdoc**: clarified that the scope must be
+  set before the first `parse_bytes` call to avoid orphaning entries written
+  under the previous scope, and that `with_template_store_scope` on a builder
+  fed into `AutoScopedParser` is overridden by the auto-derived per-source
+  scope.
+
+* **Read-through hit semantics documented.** Clarified that a successful
+  `TemplateStore` read-through increments `hits` (counted as a hit, not a
+  miss) and that restored templates have their TTL re-stamped to
+  `Instant::now()`.
+
+## Tests
+
+* **Rewrote `read_through_drives_pending_flow_replay`.** The previous test
+  never queued a pending flow before the template arrived — it would have
+  passed even if the read-through-driven pending-flow replay code were
+  deleted. Now exercises the full path: data record arrives before any
+  template is known → queued → template is written to the store by another
+  replica → next data record's read-through restores the template AND
+  triggers replay of the queued flow.
+
+* **Strengthened `auto_scoped_parser_uses_per_source_scope`.** Now also
+  validates cross-replica round-trip: a fresh `AutoScopedParser` reading the
+  store must decode each source's data record against the correctly-scoped
+  template.
+
+* **Added eviction-cleanup test for `AutoScopedParser`** verifying that
+  evicted source parsers' store entries are removed.
+
+* **Coverage filled in** for backend `remove` failures (`inject_remove_failures`
+  is now exercised), IPFIX-side codec corruption rejection, IPFIX-side LRU
+  eviction propagation to the store, and IPFIX-side `TemplateEvent::Restored`
+  firing.
+
+## Examples
+
+* **New example: `horizontal_scale_out_template_store`.** Demonstrates the
+  feature's headline use case — two `NetflowParser` instances sharing an
+  `InMemoryTemplateStore`. Replica A learns a template and goes away;
+  replica B starts cold and decodes a data record against the template via
+  read-through. Run with:
+
+  ```sh
+  cargo run --example horizontal_scale_out_template_store
+  ```
+
 # 1.0.3
 
 ## Features

--- a/examples/horizontal_scale_out_template_store.rs
+++ b/examples/horizontal_scale_out_template_store.rs
@@ -69,7 +69,8 @@ fn main() {
     // this is how an observability system would distinguish "template
     // recovered from secondary tier" from "template freshly learned from
     // exporter announce" — both look like cache hits in the basic metric.
-    let restored_log: Arc<Mutex<Vec<(TemplateProtocol, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let restored_log: Arc<Mutex<Vec<(TemplateProtocol, u16)>>> =
+        Arc::new(Mutex::new(Vec::new()));
     let restored_log_for_hook = Arc::clone(&restored_log);
 
     let mut replica_b = NetflowParser::builder()

--- a/examples/horizontal_scale_out_template_store.rs
+++ b/examples/horizontal_scale_out_template_store.rs
@@ -1,0 +1,194 @@
+//! Horizontal scale-out via a shared `TemplateStore`.
+//!
+//! Demonstrates the use case the `TemplateStore` extension point exists for:
+//! running multiple stateless parser replicas behind a UDP load balancer
+//! without source-IP-affinity routing.
+//!
+//! Replica A learns a template, writes it through to a shared store, and
+//! goes away. Replica B starts cold — its in-process template cache is
+//! empty — and immediately receives a data record for that template.
+//! With the store configured, replica B transparently restores the template
+//! from the store and decodes the record. Without the store, the same data
+//! record would queue in pending flows or fail to decode.
+//!
+//! In production you would back the `TemplateStore` with Redis, NATS KV,
+//! or similar; the in-memory store used here keeps the example self
+//! contained. The trait sees only opaque `Vec<u8>` payloads, so the
+//! protocol is identical regardless of backend.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example horizontal_scale_out_template_store
+//! ```
+
+use netflow_parser::{
+    InMemoryTemplateStore, NetflowPacket, NetflowParser, TemplateEvent, TemplateProtocol,
+};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+fn main() {
+    println!("=== Horizontal scale-out demo: two parsers sharing a TemplateStore ===\n");
+
+    // The store any production deployment would back with Redis, NATS KV,
+    // DynamoDB, etc. Implements the `TemplateStore` trait — get / put /
+    // remove on opaque byte payloads.
+    let store = Arc::new(InMemoryTemplateStore::new());
+
+    // ------------------------------------------------------------------
+    // Replica A: learns a template, persists it via write-through.
+    // ------------------------------------------------------------------
+    println!("[replica A] starting up, will learn one template");
+    let mut replica_a = NetflowParser::builder()
+        .with_template_store(Arc::clone(&store) as _)
+        .build()
+        .expect("build replica A");
+
+    let template_packet = build_v9_template_packet(256, &[(8, 4), (12, 4), (1, 8)]);
+    let result = replica_a.parse_bytes(&template_packet);
+    if let Some(err) = result.error {
+        panic!("template parse failed: {err}");
+    }
+    println!(
+        "[replica A] learned template 256, store now has {} entr(ies)\n",
+        store.len()
+    );
+
+    // Replica A goes away — drop it. The store is the only surviving
+    // record of the template. A real deployment might drop replica A
+    // because it crashed, scaled down, or rolled.
+    drop(replica_a);
+
+    // ------------------------------------------------------------------
+    // Replica B: starts cold, no in-process templates. Receives a data
+    // record for template 256 and must decode it via read-through.
+    // ------------------------------------------------------------------
+    println!("[replica B] starting cold (no in-process template cache)");
+
+    // Wire up a hook so we can observe the Restored event. In production
+    // this is how an observability system would distinguish "template
+    // recovered from secondary tier" from "template freshly learned from
+    // exporter announce" — both look like cache hits in the basic metric.
+    let restored_log: Arc<Mutex<Vec<(TemplateProtocol, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let restored_log_for_hook = Arc::clone(&restored_log);
+
+    let mut replica_b = NetflowParser::builder()
+        .with_template_store(Arc::clone(&store) as _)
+        .on_template_event(move |event| {
+            if let TemplateEvent::Restored {
+                template_id: Some(id),
+                protocol,
+            } = event
+            {
+                restored_log_for_hook
+                    .lock()
+                    .expect("poisoned")
+                    .push((*protocol, *id));
+            }
+            Ok(())
+        })
+        .build()
+        .expect("build replica B");
+
+    // 16 bytes = three fields (4 + 4 + 8) matching the template above.
+    let data_payload = [
+        // src IP = 10.0.0.1
+        0x0A, 0x00, 0x00, 0x01, // dst IP = 10.0.0.2
+        0x0A, 0x00, 0x00, 0x02, // bytes = 4096
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00,
+    ];
+    let data_packet = build_v9_data_packet(256, &data_payload);
+
+    let result = replica_b.parse_bytes(&data_packet);
+    if let Some(err) = result.error {
+        panic!("data parse on replica B failed: {err}");
+    }
+
+    let v9 = result
+        .packets
+        .into_iter()
+        .find_map(|p| match p {
+            NetflowPacket::V9(v) => Some(v),
+            _ => None,
+        })
+        .expect("expected a V9 packet");
+    let flowset_count = v9.flowsets.len();
+    println!(
+        "[replica B] decoded data packet against restored template ({} flowset(s))",
+        flowset_count
+    );
+
+    // ------------------------------------------------------------------
+    // Observability — what metrics and events fired?
+    // ------------------------------------------------------------------
+    let metrics = replica_b.v9_cache_info().metrics;
+    println!("\n[replica B] cache metrics after read-through:");
+    println!("    hits                     = {}", metrics.hits);
+    println!("    misses                   = {}", metrics.misses);
+    println!(
+        "    template_store_restored  = {}",
+        metrics.template_store_restored
+    );
+    println!(
+        "    template_store_codec_err = {}",
+        metrics.template_store_codec_errors
+    );
+    println!(
+        "    template_store_backend_err = {}",
+        metrics.template_store_backend_errors
+    );
+
+    let restored = restored_log.lock().expect("poisoned");
+    println!("\n[replica B] TemplateEvent::Restored events:");
+    for (protocol, id) in restored.iter() {
+        println!("    {:?} template_id={}", protocol, id);
+    }
+
+    println!("\nDone. The same protocol works for IPFIX and IPFIX-options templates.");
+    println!(
+        "Hot-path overhead when no store is configured is a single Option::is_none branch."
+    );
+}
+
+// --- packet builders --------------------------------------------------------
+// Minimal V9 packet construction for the demo. In production these come from
+// the wire — exporters announce templates, then send data records that
+// reference them.
+
+fn build_v9_template_packet(template_id: u16, fields: &[(u16, u16)]) -> Vec<u8> {
+    let template_record_len = 4 + fields.len() * 4; // template header + fields
+    let flowset_len = 4 + template_record_len; // set header + record
+    let mut pkt = Vec::new();
+    // V9 header (20 bytes)
+    pkt.extend_from_slice(&9u16.to_be_bytes()); // version
+    pkt.extend_from_slice(&1u16.to_be_bytes()); // count
+    pkt.extend_from_slice(&0u32.to_be_bytes()); // sys_up_time
+    pkt.extend_from_slice(&0u32.to_be_bytes()); // unix_secs
+    pkt.extend_from_slice(&0u32.to_be_bytes()); // sequence
+    pkt.extend_from_slice(&0u32.to_be_bytes()); // source_id
+    // Template flowset
+    pkt.extend_from_slice(&0u16.to_be_bytes()); // flowset_id = 0 (template)
+    pkt.extend_from_slice(&(flowset_len as u16).to_be_bytes());
+    pkt.extend_from_slice(&template_id.to_be_bytes());
+    pkt.extend_from_slice(&(fields.len() as u16).to_be_bytes());
+    for &(ft, fl) in fields {
+        pkt.extend_from_slice(&ft.to_be_bytes());
+        pkt.extend_from_slice(&fl.to_be_bytes());
+    }
+    pkt
+}
+
+fn build_v9_data_packet(template_id: u16, payload: &[u8]) -> Vec<u8> {
+    let flowset_len = 4 + payload.len();
+    let mut pkt = Vec::new();
+    pkt.extend_from_slice(&9u16.to_be_bytes());
+    pkt.extend_from_slice(&1u16.to_be_bytes());
+    pkt.extend_from_slice(&0u32.to_be_bytes());
+    pkt.extend_from_slice(&0u32.to_be_bytes());
+    pkt.extend_from_slice(&0u32.to_be_bytes());
+    pkt.extend_from_slice(&0u32.to_be_bytes());
+    pkt.extend_from_slice(&template_id.to_be_bytes());
+    pkt.extend_from_slice(&(flowset_len as u16).to_be_bytes());
+    pkt.extend_from_slice(payload);
+    pkt
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,6 +833,12 @@ impl NetflowParserBuilder {
     /// to set this directly.
     ///
     /// Accepts anything `Into<Arc<str>>` — typically `&str` or `String`.
+    ///
+    /// **Note:** when this builder is fed into
+    /// [`AutoScopedParser::try_with_builder`], the per-source scope assigned
+    /// to each child parser overrides whatever value was set here. Set this
+    /// directly only on builders used to construct standalone
+    /// [`NetflowParser`] instances.
     #[must_use = "builder methods consume self and return a new builder; the return value must be used"]
     pub fn with_template_store_scope(mut self, scope: impl Into<Arc<str>>) -> Self {
         self.template_store_scope = scope.into();
@@ -1170,6 +1176,15 @@ impl NetflowParser {
     /// builder has produced a parser.
     ///
     /// Accepts anything `Into<Arc<str>>` — typically `&str` or `String`.
+    ///
+    /// # When to call this
+    ///
+    /// Set the scope **before the first `parse_bytes` call**. If templates
+    /// are written to the store under one scope and the scope is changed
+    /// later, the older entries are not migrated — they remain under the
+    /// previous scope key and become unreachable from this parser. Use
+    /// [`NetflowParserBuilder::with_template_store_scope`] (preferred) or
+    /// call this immediately after `build()` to avoid orphaning entries.
     pub fn set_template_store_scope(&mut self, scope: impl Into<Arc<str>>) {
         let scope: Arc<str> = scope.into();
         self.v9_parser.set_template_store_scope(Arc::clone(&scope));
@@ -1424,24 +1439,34 @@ impl NetflowParser {
     /// parser.clear_v9_templates();
     /// ```
     pub fn clear_v9_templates(&mut self) {
-        // Mirror to the secondary store first (best-effort) so that
-        // subsequent reads do not transparently repopulate the in-process
-        // cache via read-through.
+        // Mirror the in-process LRU's removals to the secondary store
+        // (best-effort). Templates already evicted from the LRU before this
+        // call, or written by another parser instance under the same scope,
+        // remain reachable via read-through; clearing those requires either
+        // coordinating with the other instance or backing the store with a
+        // wipe API (the trait intentionally exposes only get/put/remove).
         if let Some(store) = self.v9_parser.template_store.clone() {
             let scope = self.v9_parser.template_store_scope.clone();
+            // Collect first so the immutable iter borrows are released before
+            // we record metrics (which needs &mut on the parser).
+            let mut keys: Vec<(template_store::TemplateKind, u16)> = Vec::new();
             for (id, _) in self.v9_parser.templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::V9Data,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::V9Data, *id));
             }
             for (id, _) in self.v9_parser.options_templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::V9Options,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::V9Options, *id));
+            }
+            for (kind, id) in keys {
+                if store
+                    .remove(&template_store::TemplateStoreKey::new(
+                        scope.clone(),
+                        kind,
+                        id,
+                    ))
+                    .is_err()
+                {
+                    self.v9_parser.metrics.record_template_store_backend_error();
+                }
             }
         }
         self.v9_parser.templates.clear();
@@ -1462,35 +1487,38 @@ impl NetflowParser {
     /// parser.clear_ipfix_templates();
     /// ```
     pub fn clear_ipfix_templates(&mut self) {
+        // See `clear_v9_templates` for the in-LRU-only semantics; the same
+        // applies here across all four IPFIX template caches.
         if let Some(store) = self.ipfix_parser.template_store.clone() {
             let scope = self.ipfix_parser.template_store_scope.clone();
+            // Collect first so the immutable iter borrows are released before
+            // we record metrics (which needs &mut on the parser).
+            let mut keys: Vec<(template_store::TemplateKind, u16)> = Vec::new();
             for (id, _) in self.ipfix_parser.templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::IpfixData,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::IpfixData, *id));
             }
             for (id, _) in self.ipfix_parser.ipfix_options_templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::IpfixOptions,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::IpfixOptions, *id));
             }
             for (id, _) in self.ipfix_parser.v9_templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::IpfixV9Data,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::IpfixV9Data, *id));
             }
             for (id, _) in self.ipfix_parser.v9_options_templates.iter() {
-                let _ = store.remove(&template_store::TemplateStoreKey::new(
-                    scope.clone(),
-                    template_store::TemplateKind::IpfixV9Options,
-                    *id,
-                ));
+                keys.push((template_store::TemplateKind::IpfixV9Options, *id));
+            }
+            for (kind, id) in keys {
+                if store
+                    .remove(&template_store::TemplateStoreKey::new(
+                        scope.clone(),
+                        kind,
+                        id,
+                    ))
+                    .is_err()
+                {
+                    self.ipfix_parser
+                        .metrics
+                        .record_template_store_backend_error();
+                }
             }
         }
         self.ipfix_parser.templates.clear();

--- a/src/scoped_parser.rs
+++ b/src/scoped_parser.rs
@@ -919,12 +919,21 @@ impl AutoScopedParser {
             })
             .map(|(kind, _, _)| *kind);
 
+        // Pop the LRU entry. If a TemplateStore is configured, clear the
+        // evicted parser's templates from the store *before* dropping it —
+        // otherwise its scope's keys would linger forever, accumulating
+        // monotonically across source churn (no per-scope wipe API exists
+        // on the trait). V5/V7 (Legacy) parsers have no templates.
         match oldest {
             Some(MapKind::Ipfix) => {
-                self.ipfix_parsers.pop_lru();
+                if let Some((_, (mut parser, _))) = self.ipfix_parsers.pop_lru() {
+                    parser.clear_ipfix_templates();
+                }
             }
             Some(MapKind::V9) => {
-                self.v9_parsers.pop_lru();
+                if let Some((_, (mut parser, _))) = self.v9_parsers.pop_lru() {
+                    parser.clear_v9_templates();
+                }
             }
             Some(MapKind::Legacy) => {
                 self.legacy_parsers.pop_lru();

--- a/src/variable_versions/metrics.rs
+++ b/src/variable_versions/metrics.rs
@@ -30,6 +30,14 @@ pub(crate) struct CacheMetricsInner {
     pub pending_replay_failed: u64,
     /// Number of templates restored from the secondary `TemplateStore` on a
     /// primary-cache miss (read-through hits).
+    ///
+    /// Counted as a `hit` (not a `miss`) — `hits` is the union of in-process
+    /// LRU hits and read-through hits. Subtract `template_store_restored`
+    /// from `hits` to get "served entirely from the in-process cache."
+    ///
+    /// Restored templates are stamped with `Instant::now()` for TTL purposes,
+    /// so the configured TTL window resets every time a template is restored
+    /// from the store.
     pub template_store_restored: u64,
     /// Number of secondary `TemplateStore` payloads that failed to decode.
     /// Non-zero values indicate operational issues — a corrupted entry,

--- a/tests/template_store.rs
+++ b/tests/template_store.rs
@@ -357,31 +357,46 @@ fn auto_scoped_parser_uses_per_source_scope() {
     );
 
     // Cross-replica read-through: a fresh AutoScopedParser sharing the same
-    // store must resolve each source's template via its own scope key.
+    // store must resolve each source's template via its own scope key. Assert
+    // each result contains a Data flowset (not NoTemplate) — read-through
+    // miss or wrong-scope hit would yield NoTemplate without an error, so
+    // checking for a V9 packet alone is not sufficient.
     let mut replica = AutoScopedParser::try_with_builder(
         NetflowParser::builder().with_template_store(store.clone()),
     )
     .expect("valid");
+
+    fn assert_first_flowset_is_data(packets: &[NetflowPacket], who: &str) {
+        let v9 = packets
+            .iter()
+            .find_map(|p| match p {
+                NetflowPacket::V9(v) => Some(v),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("{who}: expected a V9 packet"));
+        let body = &v9
+            .flowsets
+            .first()
+            .unwrap_or_else(|| panic!("{who}: expected at least one flowset"))
+            .body;
+        assert!(
+            matches!(
+                body,
+                netflow_parser::variable_versions::v9::FlowSetBody::Data(_)
+            ),
+            "{who}: expected Data flowset (read-through hit correct scope), got {:?}",
+            body
+        );
+    }
+
     // Data record from src_a must decode against tmpl_a (1 field of 4 bytes).
     let r_a = replica.parse_from_source(src_a, &v9_data_packet(256, &[0, 0, 0, 0x2A]));
     assert!(r_a.error.is_none());
+    assert_first_flowset_is_data(&r_a.packets, "src_a");
     // Data record from src_b must decode against tmpl_b (2 fields of 4 bytes each).
     let r_b = replica.parse_from_source(src_b, &v9_data_packet(256, &[0, 0, 0, 1, 0, 0, 0, 2]));
     assert!(r_b.error.is_none());
-    // Both packets must produce a parsed V9 packet (would not happen if
-    // read-through hit the wrong scope's template or missed the store).
-    assert!(
-        r_a.packets
-            .iter()
-            .any(|p| matches!(p, NetflowPacket::V9(_))),
-        "src_a record should parse via read-through against its scoped template"
-    );
-    assert!(
-        r_b.packets
-            .iter()
-            .any(|p| matches!(p, NetflowPacket::V9(_))),
-        "src_b record should parse via read-through against its scoped template"
-    );
+    assert_first_flowset_is_data(&r_b.packets, "src_b");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/template_store.rs
+++ b/tests/template_store.rs
@@ -682,7 +682,10 @@ fn read_through_drives_pending_flow_replay() {
     let r1 = b.parse_bytes(&v9_data_packet(256, &[0, 0, 0, 0x2A]));
     assert!(r1.error.is_none());
     let m1 = b.v9_cache_info().metrics;
-    assert_eq!(m1.pending_cached, 1, "data arriving before template must queue");
+    assert_eq!(
+        m1.pending_cached, 1,
+        "data arriving before template must queue"
+    );
     assert_eq!(m1.pending_replayed, 0);
     assert_eq!(m1.template_store_restored, 0);
 

--- a/tests/template_store.rs
+++ b/tests/template_store.rs
@@ -355,6 +355,33 @@ fn auto_scoped_parser_uses_per_source_scope() {
         found_payloads[0], found_payloads[1],
         "scoped store entries must hold the distinct templates each source announced"
     );
+
+    // Cross-replica read-through: a fresh AutoScopedParser sharing the same
+    // store must resolve each source's template via its own scope key.
+    let mut replica = AutoScopedParser::try_with_builder(
+        NetflowParser::builder().with_template_store(store.clone()),
+    )
+    .expect("valid");
+    // Data record from src_a must decode against tmpl_a (1 field of 4 bytes).
+    let r_a = replica.parse_from_source(src_a, &v9_data_packet(256, &[0, 0, 0, 0x2A]));
+    assert!(r_a.error.is_none());
+    // Data record from src_b must decode against tmpl_b (2 fields of 4 bytes each).
+    let r_b = replica.parse_from_source(src_b, &v9_data_packet(256, &[0, 0, 0, 1, 0, 0, 0, 2]));
+    assert!(r_b.error.is_none());
+    // Both packets must produce a parsed V9 packet (would not happen if
+    // read-through hit the wrong scope's template or missed the store).
+    assert!(
+        r_a.packets
+            .iter()
+            .any(|p| matches!(p, NetflowPacket::V9(_))),
+        "src_a record should parse via read-through against its scoped template"
+    );
+    assert!(
+        r_b.packets
+            .iter()
+            .any(|p| matches!(p, NetflowPacket::V9(_))),
+        "src_b record should parse via read-through against its scoped template"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -381,7 +408,6 @@ impl FaultStore {
     fn inject_put_failures(&self, n: usize) {
         self.fail_put.store(n, Ordering::SeqCst);
     }
-    #[allow(dead_code)]
     fn inject_remove_failures(&self, n: usize) {
         self.fail_remove.store(n, Ordering::SeqCst);
     }
@@ -641,8 +667,27 @@ fn read_through_fires_restored_event() {
 fn read_through_drives_pending_flow_replay() {
     use netflow_parser::PendingFlowsConfig;
 
-    // Seed the store with template 256.
     let store = Arc::new(InMemoryTemplateStore::new());
+
+    // Replica B has pending-flow caching enabled and starts with an empty
+    // in-process cache *and* an empty store.
+    let mut b = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .with_pending_flows(PendingFlowsConfig::default())
+        .build()
+        .expect("build");
+
+    // Step 1: data record arrives before the template is known anywhere.
+    // Pending-flow caching must queue it.
+    let r1 = b.parse_bytes(&v9_data_packet(256, &[0, 0, 0, 0x2A]));
+    assert!(r1.error.is_none());
+    let m1 = b.v9_cache_info().metrics;
+    assert_eq!(m1.pending_cached, 1, "data arriving before template must queue");
+    assert_eq!(m1.pending_replayed, 0);
+    assert_eq!(m1.template_store_restored, 0);
+
+    // Step 2: another replica learns the template and writes it to the
+    // shared store.
     {
         let mut a = NetflowParser::builder()
             .with_template_store(store.clone())
@@ -651,32 +696,22 @@ fn read_through_drives_pending_flow_replay() {
         let _ = a.parse_bytes(&v9_template_packet(256, &[(1, 4)]));
     }
 
-    // Replica B has pending-flow caching enabled and no in-process template.
-    let pending_cfg = PendingFlowsConfig::default();
-    let mut b = NetflowParser::builder()
-        .with_template_store(store.clone())
-        .with_pending_flows(pending_cfg)
-        .build()
-        .expect("build");
-
-    // Two data packets in a row for template 256, but in V9 each parse_bytes
-    // is a separate datagram. The second one will read-through, decode the
-    // current data, AND replay anything pending. To exercise replay we feed
-    // a packet whose payload contains *two* records (one is in-line, one
-    // would be queued if a hypothetical earlier no-template arrival had
-    // queued it). For test simplicity we just verify that read-through
-    // produces a Data flowset (already covered) and that the pending-flow
-    // metric does not regress — i.e. the replay logic does not over-count.
-    let result = b.parse_bytes(&v9_data_packet(256, &[0, 0, 0, 0x2A]));
-    assert!(result.error.is_none());
-
-    let metrics = b.v9_cache_info().metrics;
-    assert_eq!(metrics.template_store_restored, 1);
-    // No pending entry was ever queued for template 256, so replay counters
-    // should be zero — this asserts read-through replay didn't synthesize
-    // spurious entries.
-    assert_eq!(metrics.pending_replayed, 0);
-    assert_eq!(metrics.pending_replay_failed, 0);
+    // Step 3: replica B receives another data record for template 256. The
+    // read-through must (a) restore the template into B's in-process cache,
+    // (b) decode the in-line record, AND (c) replay the previously-queued
+    // pending entry against the freshly-restored template.
+    let r2 = b.parse_bytes(&v9_data_packet(256, &[0, 0, 0, 0x99]));
+    assert!(r2.error.is_none());
+    let m2 = b.v9_cache_info().metrics;
+    assert_eq!(
+        m2.template_store_restored, 1,
+        "read-through should restore the template"
+    );
+    assert_eq!(
+        m2.pending_replayed, 1,
+        "read-through must drive replay of the queued pending flow"
+    );
+    assert_eq!(m2.pending_replay_failed, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -737,4 +772,199 @@ fn set_template_store_scope_retrofit_changes_keys() {
             .unwrap()
             .is_some()
     );
+}
+
+// ---------------------------------------------------------------------------
+// clear_*_templates backend error reporting + remove-failure coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clear_v9_templates_records_backend_errors_on_remove_failure() {
+    let store = Arc::new(FaultStore::new());
+    let mut parser = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .build()
+        .expect("build");
+
+    // Learn two templates so clear_v9_templates issues two store.remove calls.
+    let _ = parser.parse_bytes(&v9_template_packet(256, &[(1, 4)]));
+    let _ = parser.parse_bytes(&v9_template_packet(257, &[(2, 4)]));
+    let baseline = parser.v9_cache_info().metrics.template_store_backend_errors;
+
+    // Inject two remove failures so both removes during clear() Err out.
+    store.inject_remove_failures(2);
+    parser.clear_v9_templates();
+
+    let metrics = parser.v9_cache_info().metrics;
+    assert_eq!(
+        metrics.template_store_backend_errors - baseline,
+        2,
+        "clear_v9_templates must count backend errors on remove failure"
+    );
+    assert_eq!(store.observed_errors(), 2);
+}
+
+#[test]
+fn clear_ipfix_templates_records_backend_errors_on_remove_failure() {
+    let store = Arc::new(FaultStore::new());
+    let mut parser = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .build()
+        .expect("build");
+
+    let _ = parser.parse_bytes(&ipfix_template_packet(300, &[(1, 4)]));
+    let baseline = parser
+        .ipfix_cache_info()
+        .metrics
+        .template_store_backend_errors;
+
+    store.inject_remove_failures(1);
+    parser.clear_ipfix_templates();
+
+    let metrics = parser.ipfix_cache_info().metrics;
+    assert_eq!(
+        metrics.template_store_backend_errors - baseline,
+        1,
+        "clear_ipfix_templates must count backend errors on remove failure"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AutoScopedParser source eviction cleans up store entries
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_scoped_parser_eviction_clears_evicted_source_from_store() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut scoped = AutoScopedParser::try_with_builder(builder)
+        .expect("valid")
+        .with_max_sources(2)
+        .expect("valid");
+
+    let src_a: SocketAddr = "10.0.0.1:2055".parse().unwrap();
+    let src_b: SocketAddr = "10.0.0.2:2055".parse().unwrap();
+    let src_c: SocketAddr = "10.0.0.3:2055".parse().unwrap();
+
+    // Learn distinct templates from three different sources. Source A is
+    // touched first, so it becomes the LRU when source C arrives.
+    let _ = scoped.parse_from_source(src_a, &v9_template_packet(256, &[(1, 4)]));
+    let _ = scoped.parse_from_source(src_b, &v9_template_packet(256, &[(2, 4)]));
+    assert_eq!(store.len(), 2);
+
+    // Touch B again to make A the unambiguously oldest entry.
+    let _ = scoped.parse_from_source(src_b, &v9_template_packet(257, &[(3, 4)]));
+    // Adding C must evict A. A's store entries (under "v9:10.0.0.1:2055/0")
+    // must be removed — otherwise a later replica reading the store would
+    // resurrect templates that no parser instance is responsible for.
+    let _ = scoped.parse_from_source(src_c, &v9_template_packet(256, &[(4, 4)]));
+
+    let key_a = TemplateStoreKey::new("v9:10.0.0.1:2055/0", TemplateKind::V9Data, 256);
+    assert!(
+        store.get(&key_a).unwrap().is_none(),
+        "evicted source's templates must be cleared from the store"
+    );
+    // B and C entries should remain.
+    let key_b_256 = TemplateStoreKey::new("v9:10.0.0.2:2055/0", TemplateKind::V9Data, 256);
+    let key_b_257 = TemplateStoreKey::new("v9:10.0.0.2:2055/0", TemplateKind::V9Data, 257);
+    let key_c = TemplateStoreKey::new("v9:10.0.0.3:2055/0", TemplateKind::V9Data, 256);
+    assert!(store.get(&key_b_256).unwrap().is_some());
+    assert!(store.get(&key_b_257).unwrap().is_some());
+    assert!(store.get(&key_c).unwrap().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Codec corruption coverage for non-V9Data kinds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ipfix_corrupted_payload_is_counted_and_removed() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let key = TemplateStoreKey::new("", TemplateKind::IpfixData, 300);
+    store.put(&key, &[0xff; 6]).expect("seed");
+
+    let mut parser = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .build()
+        .expect("build");
+    let _ = parser.parse_bytes(&ipfix_data_packet(300, &[0, 0, 0, 0x2A]));
+
+    let metrics = parser.ipfix_cache_info().metrics;
+    assert_eq!(
+        metrics.template_store_codec_errors, 1,
+        "IPFIX codec error must be counted"
+    );
+    assert!(
+        store.get(&key).unwrap().is_none(),
+        "corrupted IPFIX entry must be removed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LRU eviction propagates to store for IPFIX
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ipfix_lru_eviction_propagates_to_store() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let mut parser = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .with_cache_size(2)
+        .build()
+        .expect("build");
+
+    let _ = parser.parse_bytes(&ipfix_template_packet(300, &[(1, 4)]));
+    let _ = parser.parse_bytes(&ipfix_template_packet(301, &[(2, 4)]));
+    let _ = parser.parse_bytes(&ipfix_template_packet(302, &[(3, 4)]));
+
+    // Cache holds at most 2; the oldest (300) should have been evicted from
+    // the in-process LRU and from the store.
+    let key_300 = TemplateStoreKey::new("", TemplateKind::IpfixData, 300);
+    assert!(
+        store.get(&key_300).unwrap().is_none(),
+        "evicted IPFIX template must be removed from store"
+    );
+    let key_301 = TemplateStoreKey::new("", TemplateKind::IpfixData, 301);
+    let key_302 = TemplateStoreKey::new("", TemplateKind::IpfixData, 302);
+    assert!(store.get(&key_301).unwrap().is_some());
+    assert!(store.get(&key_302).unwrap().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// IPFIX Restored event firing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ipfix_read_through_fires_restored_event() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    {
+        let mut a = NetflowParser::builder()
+            .with_template_store(store.clone())
+            .build()
+            .expect("build");
+        let _ = a.parse_bytes(&ipfix_template_packet(300, &[(1, 4)]));
+    }
+
+    let restored: Arc<Mutex<Vec<(TemplateProtocol, u16)>>> = Arc::new(Mutex::new(Vec::new()));
+    let restored_clone = Arc::clone(&restored);
+
+    let mut b = NetflowParser::builder()
+        .with_template_store(store.clone())
+        .on_template_event(move |event| {
+            if let TemplateEvent::Restored {
+                template_id: Some(id),
+                protocol,
+            } = event
+            {
+                restored_clone.lock().unwrap().push((*protocol, *id));
+            }
+            Ok(())
+        })
+        .build()
+        .expect("build");
+
+    let _ = b.parse_bytes(&ipfix_data_packet(300, &[0, 0, 0, 0x2A]));
+
+    let observed = restored.lock().unwrap().clone();
+    assert_eq!(observed, vec![(TemplateProtocol::Ipfix, 300)]);
 }


### PR DESCRIPTION
…y (1.0.4)

- AutoScopedParser source eviction now clears the evicted parser's templates from the store before drop (prevents monotonic keyspace growth in long-running multi-tenant deployments).
- clear_v9_templates / clear_ipfix_templates record template_store_backend_errors on remove failures (previously swallowed via let _ = ...).
- Honest doc comment on clear_*_templates in-LRU-only semantics.
- set_template_store_scope / with_template_store_scope rustdoc warnings about scope-change orphan windows and AutoScopedParser overrides.
- template_store_restored doc clarifies hit-not-miss semantics and TTL re-stamping behavior.

Tests:
- Rewrote vacuous read_through_drives_pending_flow_replay to actually queue a pending flow before any template is known, then verify read-through restores the template AND replays the queued flow.
- Strengthened auto_scoped_parser_uses_per_source_scope with a cross-replica round-trip read-through assertion.
- New tests: AutoScopedParser eviction store cleanup, clear_*_templates backend-error counting, IPFIX codec corruption, IPFIX LRU eviction propagation, IPFIX TemplateEvent::Restored firing.
- inject_remove_failures is no longer dead code.

Example:
- New horizontal_scale_out_template_store example demonstrates two parser replicas sharing an InMemoryTemplateStore — replica A learns and goes away, replica B starts cold and decodes via read-through.