### PR TITLE
Allow repeated IPFIX IEs and safe zero-length NetFlow v9 fields

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,6 +95,33 @@ mod base_tests {
         assert_yaml_snapshot!(v9);
     }
 
+    #[test]
+    fn v9_zero_length_options_member_parses_data_without_looping() {
+        use crate::variable_versions::v9::FlowSetBody;
+
+        // One zero-length System scope field and one two-byte option field.
+        // The complete record still consumes input through the option field.
+        let template = hex::decode(
+            "00090001000000000000000000000000000000010001001401000004000400010000002900020000",
+        )
+        .unwrap();
+        let data =
+            hex::decode("00090001000000000000000000000000000000010100000800070000").unwrap();
+        let mut parser = NetflowParser::default();
+
+        let template_result = parser.parse_bytes(&template);
+        assert!(template_result.error.is_none());
+        assert!(template_result.packets.iter().any(|packet| {
+            matches!(packet, NetflowPacket::V9(packet) if packet.flowsets.iter().any(|flowset| matches!(flowset.body, FlowSetBody::OptionsTemplate(_))))
+        }));
+
+        let data_result = parser.parse_bytes(&data);
+        assert!(data_result.error.is_none());
+        assert!(data_result.packets.iter().any(|packet| {
+            matches!(packet, NetflowPacket::V9(packet) if packet.flowsets.iter().any(|flowset| matches!(flowset.body, FlowSetBody::OptionsData(_))))
+        }));
+    }
+
     // Verify that combined v9 options template, data template, and data records parse together
     #[test]
     fn can_read_v9_with_options_template_and_template() {
@@ -187,6 +214,33 @@ mod base_tests {
         } else {
             panic!("Packet is not IPFix");
         }
+    }
+
+    #[test]
+    fn ipfix_repeated_information_elements_parse_template_and_data() {
+        use crate::variable_versions::ipfix::FlowSetBody;
+
+        // Template 256 repeats sourceIPv4Address twice before destinationIPv4Address.
+        let template = hex::decode(
+            "000a002400000000000000000000000100020014010000030008000400080004000c0004",
+        )
+        .unwrap();
+        let data =
+            hex::decode("000a0020000000000000000000000001010000100a0000010a0000020a000003")
+                .unwrap();
+        let mut parser = NetflowParser::default();
+
+        let template_result = parser.parse_bytes(&template);
+        assert!(template_result.error.is_none());
+        assert!(template_result.packets.iter().any(|packet| {
+            matches!(packet, NetflowPacket::IPFix(packet) if packet.flowsets.iter().any(|flowset| matches!(flowset.body, FlowSetBody::Template(_) | FlowSetBody::Templates(_))))
+        }));
+
+        let data_result = parser.parse_bytes(&data);
+        assert!(data_result.error.is_none());
+        assert!(data_result.packets.iter().any(|packet| {
+            matches!(packet, NetflowPacket::IPFix(packet) if packet.flowsets.iter().any(|flowset| matches!(flowset.body, FlowSetBody::Data(_))))
+        }));
     }
 
     // Verify that an IPFIX packet with template fields is parsed correctly
@@ -654,9 +708,9 @@ mod base_tests {
         assert!(template.is_valid(&parser));
     }
 
-    // Verify that an IPFIX template with duplicate field/enterprise pairs is rejected as invalid
+    // RFC 7011 Section 8 requires collectors to support repeated identical IEs.
     #[test]
-    fn test_ipfix_template_validation_duplicate_fields() {
+    fn test_ipfix_template_validation_allows_duplicate_fields() {
         use crate::variable_versions::ipfix::{IPFixParser, Template, TemplateField};
 
         let config = Config {
@@ -675,7 +729,7 @@ mod base_tests {
 
         let parser = IPFixParser::try_new(config).unwrap();
 
-        // Template with duplicate (field_type_number, enterprise_number) pair should fail
+        // Repeated (field_type_number, enterprise_number) pairs are valid.
         let template = Template {
             template_id: 256,
             field_count: 3,
@@ -701,7 +755,121 @@ mod base_tests {
             ],
         };
 
+        assert!(template.is_valid(&parser));
+    }
+
+    #[test]
+    fn test_v9_template_validation_allows_zero_length_member() {
+        use crate::variable_versions::v9::lookup::V9Field;
+        use crate::variable_versions::v9::{Template, TemplateField, V9Parser};
+
+        let config = Config {
+            max_template_cache_size: 100,
+            max_field_count: 10000,
+            max_template_total_size: usize::from(u16::MAX),
+            max_error_sample_size: 256,
+            max_records_per_flowset:
+                crate::variable_versions::config::DEFAULT_MAX_RECORDS_PER_FLOWSET,
+            ttl_config: None,
+            enterprise_registry: Arc::new(EnterpriseFieldRegistry::new()),
+            pending_flows_config: None,
+            template_store: None,
+            template_store_scope: std::sync::Arc::from(""),
+        };
+        let parser = V9Parser::try_new(config).unwrap();
+
+        let template = Template {
+            template_id: 256,
+            field_count: 2,
+            fields: vec![
+                TemplateField {
+                    field_type_number: 1,
+                    field_type: V9Field::InBytes,
+                    field_length: 0,
+                },
+                TemplateField {
+                    field_type_number: 2,
+                    field_type: V9Field::InPkts,
+                    field_length: 4,
+                },
+            ],
+        };
+
+        assert!(template.is_valid(&parser));
+    }
+
+    #[test]
+    fn test_v9_template_validation_rejects_all_zero_length_fields() {
+        use crate::variable_versions::v9::lookup::V9Field;
+        use crate::variable_versions::v9::{Template, TemplateField, V9Parser};
+
+        let config = Config {
+            max_template_cache_size: 100,
+            max_field_count: 10000,
+            max_template_total_size: usize::from(u16::MAX),
+            max_error_sample_size: 256,
+            max_records_per_flowset:
+                crate::variable_versions::config::DEFAULT_MAX_RECORDS_PER_FLOWSET,
+            ttl_config: None,
+            enterprise_registry: Arc::new(EnterpriseFieldRegistry::new()),
+            pending_flows_config: None,
+            template_store: None,
+            template_store_scope: std::sync::Arc::from(""),
+        };
+        let parser = V9Parser::try_new(config).unwrap();
+
+        let template = Template {
+            template_id: 256,
+            field_count: 1,
+            fields: vec![TemplateField {
+                field_type_number: 1,
+                field_type: V9Field::InBytes,
+                field_length: 0,
+            }],
+        };
+
         assert!(!template.is_valid(&parser));
+    }
+
+    #[test]
+    fn test_v9_options_template_validation_allows_zero_length_scope_member() {
+        use crate::variable_versions::v9::lookup::{ScopeFieldType, V9Field};
+        use crate::variable_versions::v9::{
+            OptionsTemplate, OptionsTemplateScopeField, TemplateField, V9Parser,
+        };
+
+        let config = Config {
+            max_template_cache_size: 100,
+            max_field_count: 10000,
+            max_template_total_size: usize::from(u16::MAX),
+            max_error_sample_size: 256,
+            max_records_per_flowset:
+                crate::variable_versions::config::DEFAULT_MAX_RECORDS_PER_FLOWSET,
+            ttl_config: None,
+            enterprise_registry: Arc::new(EnterpriseFieldRegistry::new()),
+            pending_flows_config: None,
+            template_store: None,
+            template_store_scope: std::sync::Arc::from(""),
+        };
+        let parser = V9Parser::try_new(config).unwrap();
+
+        let template = OptionsTemplate {
+            template_id: 256,
+            options_scope_length: 4,
+            options_length: 4,
+            scope_fields: vec![OptionsTemplateScopeField {
+                field_type_number: 1,
+                field_type: ScopeFieldType::System,
+                field_length: 0,
+            }],
+            option_fields: vec![TemplateField {
+                field_type_number: 34,
+                field_type: V9Field::SamplingInterval,
+                field_length: 4,
+            }],
+        };
+
+        assert!(template.is_valid(&parser));
     }
 
     // Verify that an IPFIX template with same field type but different enterprise numbers is valid

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -1135,13 +1135,13 @@ impl FlowSetBody {
                 FlowSetBody::V9Templates,
                 |t: &V9Template, p: &IPFixParser| {
                     // Validate V9 templates using IPFIX parser limits.
-                    // V9 does not support variable-length fields, so reject
-                    // zero-length and the variable-length sentinel 65535.
+                    // V9 does not support variable-length fields. Individual
+                    // zero-length fields are safe when the complete record has
+                    // a nonzero size.
                     usize::from(t.field_count) <= p.max_field_count
                         && !t.fields.is_empty()
-                        && t.fields
-                            .iter()
-                            .all(|f| f.field_length > 0 && f.field_length != 65535)
+                        && t.fields.iter().all(|f| f.field_length != 65535)
+                        && t.get_total_size() > 0
                         && usize::from(t.get_total_size()) <= p.max_template_total_size
                         && !t.has_duplicate_fields()
                 },
@@ -1163,14 +1163,13 @@ impl FlowSetBody {
                         && scope_count <= p.max_field_count
                         && option_count <= p.max_field_count
                         && scope_count.saturating_add(option_count) <= p.max_field_count
+                        && t.get_total_size() > 0
                         && usize::from(t.get_total_size()) <= p.max_template_total_size
                         && !t.has_duplicate_scope_fields()
                         && !t.has_duplicate_option_fields()
-                        // V9 does not support variable-length fields; reject any
-                        // zero-length or variable-length sentinel (65535) fields,
-                        // consistent with the V9 parser's own validation.
-                        && t.scope_fields.iter().all(|f| f.field_length > 0 && f.field_length != 65535)
-                        && t.option_fields.iter().all(|f| f.field_length > 0 && f.field_length != 65535)
+                        // V9 does not support the IPFIX variable-length sentinel.
+                        && t.scope_fields.iter().all(|f| f.field_length != 65535)
+                        && t.option_fields.iter().all(|f| f.field_length != 65535)
                 },
                 |parser, templates| parser.add_v9_options_templates(templates),
                 None, // V9 doesn't support template withdrawal

--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -405,31 +405,6 @@ pub(crate) trait CommonTemplate {
             return false;
         }
 
-        // Check for duplicate field IDs within scope and option fields separately.
-        // RFC 7011 Section 3.4.2.2 allows a scope field and an option field to
-        // share the same (field_type_number, enterprise_number) — they live in
-        // different conceptual arrays.  For regular Templates (no scope fields),
-        // this degenerates to a single-pass check over all fields.
-        let scope_count = self.get_scope_field_count().map(usize::from).unwrap_or(0);
-        let fields = self.get_fields();
-
-        let mut seen = std::collections::HashSet::with_capacity(fields.len());
-        // Check scope fields for duplicates among themselves
-        for field in fields.iter().take(scope_count) {
-            let key = (field.field_type_number, field.enterprise_number);
-            if !seen.insert(key) {
-                return false;
-            }
-        }
-        // Check option fields for duplicates among themselves
-        seen.clear();
-        for field in fields.iter().skip(scope_count) {
-            let key = (field.field_type_number, field.enterprise_number);
-            if !seen.insert(key) {
-                return false;
-            }
-        }
-
         true
     }
 }

--- a/src/variable_versions/v9/parser.rs
+++ b/src/variable_versions/v9/parser.rs
@@ -807,21 +807,16 @@ impl Template {
             return false;
         }
 
-        // Check fields are not empty and all fields have valid length
-        // (V9 does not support variable-length fields, so every field must have a concrete size;
-        // reject both zero-length and the variable-length sentinel 65535)
-        if self.fields.is_empty()
-            || self
-                .fields
-                .iter()
-                .any(|f| f.field_length == 0 || f.field_length == 65535)
-        {
+        // V9 does not support variable-length fields, so reject the IPFIX
+        // variable-length sentinel. Individual zero-length fields are valid as
+        // long as the complete record still consumes input.
+        if self.fields.is_empty() || self.fields.iter().any(|f| f.field_length == 65535) {
             return false;
         }
 
         // Check total size limit
         let total_size = usize::from(self.get_total_size());
-        if total_size > max_template_total_size {
+        if total_size == 0 || total_size > max_template_total_size {
             return false;
         }
 
@@ -883,16 +878,11 @@ impl OptionsTemplate {
             return false;
         }
 
-        // V9 does not support variable-length fields; reject zero-length
-        // (would cause infinite loops) and the variable-length sentinel 65535.
-        if self
-            .scope_fields
-            .iter()
-            .any(|f| f.field_length == 0 || f.field_length == 65535)
-            || self
-                .option_fields
-                .iter()
-                .any(|f| f.field_length == 0 || f.field_length == 65535)
+        // V9 does not support variable-length fields. Individual zero-length
+        // fields are safe when another field makes the complete record consume
+        // input; an all-zero template is rejected below.
+        if self.scope_fields.iter().any(|f| f.field_length == 65535)
+            || self.option_fields.iter().any(|f| f.field_length == 65535)
         {
             return false;
         }
@@ -907,7 +897,7 @@ impl OptionsTemplate {
 
         // Check total size limit
         let total_size = usize::from(self.get_total_size());
-        if total_size > max_template_total_size {
+        if total_size == 0 || total_size > max_template_total_size {
             return false;
         }
 


### PR DESCRIPTION
## Summary

- Accept repeated Information Elements in IPFIX templates, as required by RFC 7011 Section 8.
- Allow individual zero-length fields in NetFlow v9 templates and options templates when the complete record still has a nonzero size.
- Continue rejecting all-zero records and the IPFIX variable-length sentinel in v9 templates.
- Apply the same v9 validation rules to v9 templates carried through the IPFIX parser.

## Motivation

The duplicate-field check rejects valid IPFIX templates that repeat the same Information Element. RFC 7011 explicitly requires collectors to support this pattern.

The v9 zero-length check rejects complete records that are safe to parse because another member consumes input. Rejecting only templates whose total record size is zero preserves the infinite-loop guard without discarding those records.

## Tests

- Added end-to-end template and data parsing tests for both cases.
- Added validation tests for safe zero-length members and all-zero rejection.
- `cargo test`
- `cargo clippy --all -- -D warnings`
- `cargo test --doc`
- `./scripts/check-readme-sync.sh`

RFC reference: https://www.rfc-editor.org/rfc/rfc7011.html#section-8