### PR TITLE
fix: accept repeated NetFlow v9 fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netflow_parser"
 description = "Parser for Netflow Cisco V5, V7, V9, IPFIX"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Michael Mileusnich <michael.mileusnich@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -252,10 +252,10 @@ The parser also automatically validates:
 - **Template Total Size**: Maximum sum of all field lengths per template (default: u16::MAX = 65,535 bytes)
   - Prevents DoS attacks via templates with excessive total field lengths
   - Configurable via `Config::max_template_total_size`
-- **Duplicate Field Detection**: Templates with duplicate field IDs are rejected
-  - For V9: Validates unique `field_type_number` values
-  - For IPFIX: Validates unique `(field_type_number, enterprise_number)` pairs
-  - Catches malformed or corrupted template definitions
+- **Repeated Fields**: Repeated field descriptors are valid and retained in
+  wire order for both V9 and IPFIX
+  - Each occurrence is decoded as a distinct value in the record
+  - Descriptor order is significant and preserved
 
 ### Template TTL (Time-to-Live)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,13 @@
+# 1.0.6
+
+## Fixes
+
+* **Accept repeated NetFlow v9 fields.** NetFlow v9 templates are ordered field
+  lists and may contain the same field more than once. The parser previously
+  rejected those templates. Repeated data, scope, and option fields are now
+  accepted and every value is preserved in wire order. This applies to native
+  NetFlow v9 templates and to v9-style templates parsed through the IPFIX path.
+
 # 1.0.5
 
 ## Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,7 +156,6 @@ The parser includes several DoS mitigations:
 - **Template Total Size Validation:** Maximum 65,535 bytes per template
 - **Error Sample Size Limit:** Default 256 bytes to prevent memory exhaustion
 - **LRU Template Cache:** Prevents unbounded cache growth
-- **Duplicate Field Detection:** Rejects malformed templates
 
 ### Memory Safety
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -612,9 +612,9 @@ mod base_tests {
         assert!(!template.is_valid(&parser));
     }
 
-    // Verify that a v9 template with duplicate field type numbers is rejected as invalid
+    // Repeated descriptors are valid and their order is significant.
     #[test]
-    fn test_template_validation_duplicate_fields() {
+    fn test_v9_template_validation_allows_duplicate_fields() {
         use crate::variable_versions::v9::lookup::V9Field;
         use crate::variable_versions::v9::{Template, TemplateField, V9Parser};
 
@@ -634,7 +634,6 @@ mod base_tests {
 
         let parser = V9Parser::try_new(config).unwrap();
 
-        // Template with duplicate field_type_number (1) should fail validation
         let template = Template {
             template_id: 256,
             field_count: 3,
@@ -645,7 +644,7 @@ mod base_tests {
                     field_length: 4,
                 },
                 TemplateField {
-                    field_type_number: 1, // Duplicate!
+                    field_type_number: 1,
                     field_type: V9Field::InBytes,
                     field_length: 4,
                 },
@@ -657,7 +656,7 @@ mod base_tests {
             ],
         };
 
-        assert!(!template.is_valid(&parser));
+        assert!(template.is_valid(&parser));
     }
 
     // Verify that a well-formed v9 template with unique fields passes validation

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -1143,7 +1143,6 @@ impl FlowSetBody {
                         && t.fields.iter().all(|f| f.field_length != 65535)
                         && t.get_total_size() > 0
                         && usize::from(t.get_total_size()) <= p.max_template_total_size
-                        && !t.has_duplicate_fields()
                 },
                 |parser, templates| parser.add_v9_templates(templates),
                 None, // V9 doesn't support template withdrawal
@@ -1165,8 +1164,6 @@ impl FlowSetBody {
                         && scope_count.saturating_add(option_count) <= p.max_field_count
                         && t.get_total_size() > 0
                         && usize::from(t.get_total_size()) <= p.max_template_total_size
-                        && !t.has_duplicate_scope_fields()
-                        && !t.has_duplicate_option_fields()
                         // V9 does not support the IPFIX variable-length sentinel.
                         && t.scope_fields.iter().all(|f| f.field_length != 65535)
                         && t.option_fields.iter().all(|f| f.field_length != 65535)

--- a/src/variable_versions/v9/parser.rs
+++ b/src/variable_versions/v9/parser.rs
@@ -820,11 +820,6 @@ impl Template {
             return false;
         }
 
-        // Check for duplicate field type numbers
-        if self.has_duplicate_fields() {
-            return false;
-        }
-
         true
     }
 
@@ -898,16 +893,6 @@ impl OptionsTemplate {
         // Check total size limit
         let total_size = usize::from(self.get_total_size());
         if total_size == 0 || total_size > max_template_total_size {
-            return false;
-        }
-
-        // Check for duplicate field type numbers in scope fields
-        if self.has_duplicate_scope_fields() {
-            return false;
-        }
-
-        // Check for duplicate field type numbers in option fields
-        if self.has_duplicate_option_fields() {
             return false;
         }
 

--- a/tests/repeated_v9_fields.rs
+++ b/tests/repeated_v9_fields.rs
@@ -1,0 +1,236 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody as IpfixFlowSetBody;
+use netflow_parser::variable_versions::v9::lookup::V9Field;
+use netflow_parser::variable_versions::v9::{
+    Data, FlowSetBody as V9FlowSetBody, OptionsData, ScopeDataField,
+};
+use netflow_parser::{InMemoryTemplateStore, NetflowPacket, NetflowParser};
+use std::sync::Arc;
+
+const TEMPLATE_ID: u16 = 256;
+const OPTIONS_TEMPLATE_ID: u16 = 257;
+
+fn v9_packet(flowset_id: u16, body: &[u8], sequence: u32) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(24 + body.len());
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&sequence.to_be_bytes());
+    packet.extend_from_slice(&1u32.to_be_bytes());
+    packet.extend_from_slice(&flowset_id.to_be_bytes());
+    packet.extend_from_slice(&u16::try_from(4 + body.len()).unwrap().to_be_bytes());
+    packet.extend_from_slice(body);
+    packet
+}
+
+fn ipfix_message(set_id: u16, body: &[u8], sequence: u32) -> Vec<u8> {
+    let mut message = Vec::with_capacity(20 + body.len());
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(20 + body.len()).unwrap().to_be_bytes());
+    message.extend_from_slice(&0u32.to_be_bytes());
+    message.extend_from_slice(&sequence.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&set_id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(4 + body.len()).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+fn repeated_template() -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    for _ in 0..2 {
+        body.extend_from_slice(&1u16.to_be_bytes());
+        body.extend_from_slice(&4u16.to_be_bytes());
+    }
+    body
+}
+
+fn repeated_data() -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&11u32.to_be_bytes());
+    body.extend_from_slice(&22u32.to_be_bytes());
+    body
+}
+
+fn repeated_options_template() -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&OPTIONS_TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&8u16.to_be_bytes());
+    body.extend_from_slice(&8u16.to_be_bytes());
+    for _ in 0..2 {
+        body.extend_from_slice(&1u16.to_be_bytes());
+        body.extend_from_slice(&4u16.to_be_bytes());
+    }
+    for _ in 0..2 {
+        body.extend_from_slice(&42u16.to_be_bytes());
+        body.extend_from_slice(&4u16.to_be_bytes());
+    }
+    body.extend_from_slice(&[0; 2]);
+    body
+}
+
+fn repeated_options_data() -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(&[1, 2, 3, 4]);
+    body.extend_from_slice(&[5, 6, 7, 8]);
+    body.extend_from_slice(&33u32.to_be_bytes());
+    body.extend_from_slice(&44u32.to_be_bytes());
+    body
+}
+
+fn assert_repeated_data(data: &Data) {
+    assert_eq!(data.fields.len(), 1);
+    let record = &data.fields[0];
+    assert_eq!(record.len(), 2);
+    assert_eq!(record[0].0, V9Field::InBytes);
+    assert_eq!(record[1].0, V9Field::InBytes);
+    assert_eq!(u32::try_from(&record[0].1).unwrap(), 11);
+    assert_eq!(u32::try_from(&record[1].1).unwrap(), 22);
+}
+
+fn assert_repeated_options_data(data: &OptionsData) {
+    assert_eq!(data.fields.len(), 1);
+    let record = &data.fields[0];
+    assert_eq!(record.scope_fields.len(), 2);
+    assert_eq!(
+        record.scope_fields,
+        [
+            ScopeDataField::System(vec![1, 2, 3, 4]),
+            ScopeDataField::System(vec![5, 6, 7, 8]),
+        ]
+    );
+    assert_eq!(record.options_fields.len(), 2);
+    assert_eq!(record.options_fields[0].0, V9Field::TotalFlowsExp);
+    assert_eq!(record.options_fields[1].0, V9Field::TotalFlowsExp);
+    assert_eq!(u32::try_from(&record.options_fields[0].1).unwrap(), 33);
+    assert_eq!(u32::try_from(&record.options_fields[1].1).unwrap(), 44);
+}
+
+#[test]
+fn netflow_v9_preserves_repeated_template_fields_in_wire_order() {
+    let mut parser = NetflowParser::default();
+    let template = parser.parse_bytes(&v9_packet(0, &repeated_template(), 1));
+    assert!(template.error.is_none(), "{:?}", template.error);
+
+    let data = parser.parse_bytes(&v9_packet(TEMPLATE_ID, &repeated_data(), 2));
+    assert!(data.error.is_none(), "{:?}", data.error);
+    let Some(NetflowPacket::V9(packet)) = data.packets.first() else {
+        panic!("expected v9 packet");
+    };
+    let V9FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected v9 data");
+    };
+    assert_repeated_data(data);
+}
+
+#[test]
+fn netflow_v9_preserves_repeated_options_fields_in_wire_order() {
+    let mut parser = NetflowParser::default();
+    let template = parser.parse_bytes(&v9_packet(1, &repeated_options_template(), 1));
+    assert!(template.error.is_none(), "{:?}", template.error);
+
+    let data = parser.parse_bytes(&v9_packet(OPTIONS_TEMPLATE_ID, &repeated_options_data(), 2));
+    assert!(data.error.is_none(), "{:?}", data.error);
+    let Some(NetflowPacket::V9(packet)) = data.packets.first() else {
+        panic!("expected v9 packet");
+    };
+    let V9FlowSetBody::OptionsData(data) = &packet.flowsets[0].body else {
+        panic!("expected v9 options data");
+    };
+    assert_repeated_options_data(data);
+}
+
+#[test]
+fn ipfix_preserves_repeated_fields_in_embedded_v9_templates() {
+    let mut parser = NetflowParser::default();
+    let template = parser.parse_bytes(&ipfix_message(0, &repeated_template(), 1));
+    assert!(template.error.is_none(), "{:?}", template.error);
+
+    let data = parser.parse_bytes(&ipfix_message(TEMPLATE_ID, &repeated_data(), 2));
+    assert!(data.error.is_none(), "{:?}", data.error);
+    let Some(NetflowPacket::IPFix(packet)) = data.packets.first() else {
+        panic!("expected IPFIX message");
+    };
+    let IpfixFlowSetBody::V9Data(data) = &packet.flowsets[0].body else {
+        panic!("expected embedded v9 data");
+    };
+    assert_repeated_data(data);
+}
+
+#[test]
+fn ipfix_preserves_repeated_options_fields_in_embedded_v9_templates() {
+    let mut parser = NetflowParser::default();
+    let template = parser.parse_bytes(&ipfix_message(1, &repeated_options_template(), 1));
+    assert!(template.error.is_none(), "{:?}", template.error);
+
+    let data = parser.parse_bytes(&ipfix_message(
+        OPTIONS_TEMPLATE_ID,
+        &repeated_options_data(),
+        2,
+    ));
+    assert!(data.error.is_none(), "{:?}", data.error);
+    let Some(NetflowPacket::IPFix(packet)) = data.packets.first() else {
+        panic!("expected IPFIX message");
+    };
+    let IpfixFlowSetBody::V9OptionsData(data) = &packet.flowsets[0].body else {
+        panic!("expected embedded v9 options data");
+    };
+    assert_repeated_options_data(data);
+}
+
+#[test]
+fn template_store_preserves_repeated_v9_fields() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    {
+        let mut writer = NetflowParser::builder()
+            .with_template_store(store.clone())
+            .build()
+            .unwrap();
+        let result = writer.parse_bytes(&v9_packet(0, &repeated_template(), 1));
+        assert!(result.error.is_none(), "{:?}", result.error);
+    }
+
+    let mut reader = NetflowParser::builder()
+        .with_template_store(store)
+        .build()
+        .unwrap();
+    let result = reader.parse_bytes(&v9_packet(TEMPLATE_ID, &repeated_data(), 2));
+    assert!(result.error.is_none(), "{:?}", result.error);
+    let Some(NetflowPacket::V9(packet)) = result.packets.first() else {
+        panic!("expected v9 packet");
+    };
+    let V9FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected v9 data");
+    };
+    assert_repeated_data(data);
+}
+
+#[test]
+fn template_store_preserves_repeated_v9_options_fields() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    {
+        let mut writer = NetflowParser::builder()
+            .with_template_store(store.clone())
+            .build()
+            .unwrap();
+        let result = writer.parse_bytes(&v9_packet(1, &repeated_options_template(), 1));
+        assert!(result.error.is_none(), "{:?}", result.error);
+    }
+
+    let mut reader = NetflowParser::builder()
+        .with_template_store(store)
+        .build()
+        .unwrap();
+    let result =
+        reader.parse_bytes(&v9_packet(OPTIONS_TEMPLATE_ID, &repeated_options_data(), 2));
+    assert!(result.error.is_none(), "{:?}", result.error);
+    let Some(NetflowPacket::V9(packet)) = result.packets.first() else {
+        panic!("expected v9 packet");
+    };
+    let V9FlowSetBody::OptionsData(data) = &packet.flowsets[0].body else {
+        panic!("expected v9 options data");
+    };
+    assert_repeated_options_data(data);
+}


### PR DESCRIPTION
## Problem

Valid NetFlow v9 templates may contain the same field more than once. The parser rejected these templates, so their data records could not be decoded.

This affected:

- NetFlow v9 data templates
- NetFlow v9 options templates
- NetFlow v9 templates carried through the IPFIX parser

Templates are ordered field lists. Repeated fields are valid and their values must remain in that order. This is explicitly required for IPFIX by [RFC 7011, section 8](https://www.rfc-editor.org/rfc/rfc7011.html#section-8).

## Fix

- Accept repeated data, scope, and option fields.
- Preserve every repeated value in template order.
- Keep the existing size, field-count, sentinel, and packet-framing limits.
- Keep the public API unchanged.

## Verification

- Six regression tests cover native NetFlow v9, NetFlow v9 through IPFIX, and persisted templates.
- Each regression fails before this fix and passes after it.
- The full project checks pass, including the no-default-features tests.

## Release

The crate version is bumped to 1.0.6 and the change is documented in `RELEASES.md`, as requested.
