### PR TITLE
fix: enforce one IPFIX template owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ let parser = NetflowParser::builder()
 - Empty template caches reserve no entry storage; each cache grows as templates arrive
 - When the cache is full, the least recently used template is evicted
 - Templates are keyed by template ID (per source)
+- Native and V9-style IPFIX data and Options templates share one Template ID namespace;
+  each accepted definition becomes the sole owner of its ID
 - Each parser instance maintains its own template cache
 - For multi-source deployments, use `RouterScopedParser` (see Template Management section)
 

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -1060,6 +1060,38 @@ impl IPFixParser {
         }
     }
 
+    fn drain_pending_template_ids(&mut self, template_ids: &[u16]) {
+        let Some(cache) = self.pending_flows.as_mut() else {
+            return;
+        };
+        for &template_id in template_ids {
+            let dropped = cache.drain(template_id, &mut self.metrics).len() as u64;
+            if dropped > 0 {
+                self.metrics.record_pending_dropped_n(dropped);
+            }
+        }
+    }
+
+    fn remove_data_template_owners(&mut self, template_ids: &[u16]) {
+        for &template_id in template_ids {
+            self.templates.pop(&template_id);
+            self.v9_templates.pop(&template_id);
+            self.evict_from_store(TemplateKind::IpfixData, template_id);
+            self.evict_from_store(TemplateKind::IpfixV9Data, template_id);
+        }
+        self.drain_pending_template_ids(template_ids);
+    }
+
+    fn remove_options_template_owners(&mut self, template_ids: &[u16]) {
+        for &template_id in template_ids {
+            self.ipfix_options_templates.pop(&template_id);
+            self.v9_options_templates.pop(&template_id);
+            self.evict_from_store(TemplateKind::IpfixOptions, template_id);
+            self.evict_from_store(TemplateKind::IpfixV9Options, template_id);
+        }
+        self.drain_pending_template_ids(template_ids);
+    }
+
     /// Remove an IPFIX template by ID (RFC 7011 Section 8.1 template withdrawal).
     /// Also purges any pending flows cached under this template ID to prevent
     /// stale data from being replayed against a replacement template.
@@ -1069,34 +1101,13 @@ impl IPFixParser {
     /// handles both individual and bulk withdrawal.
     fn withdraw_ipfix_template(&mut self, template_id: u16) {
         if template_id == DATA_TEMPLATE_IPFIX_ID {
-            // "Withdraw all data templates" — clear entire data template
-            // cache and drain pending flows only for those template IDs.
-            // Pending flows for options template IDs are left untouched
-            // since those templates remain valid.
-            let ids: Vec<u16> = self.templates.iter().map(|(&id, _)| id).collect();
-            for id in &ids {
-                self.templates.pop(id);
-                self.evict_from_store(TemplateKind::IpfixData, *id);
-            }
-            if let Some(ref mut cache) = self.pending_flows {
-                for &id in &ids {
-                    let drained = cache.drain(id, &mut self.metrics);
-                    let n = drained.len() as u64;
-                    if n > 0 {
-                        self.metrics.record_pending_dropped_n(n);
-                    }
-                }
-            }
+            let mut ids: Vec<u16> = self.templates.iter().map(|(&id, _)| id).collect();
+            ids.extend(self.v9_templates.iter().map(|(&id, _)| id));
+            ids.sort_unstable();
+            ids.dedup();
+            self.remove_data_template_owners(&ids);
         } else {
-            self.templates.pop(&template_id);
-            self.evict_from_store(TemplateKind::IpfixData, template_id);
-            if let Some(ref mut cache) = self.pending_flows {
-                let drained = cache.drain(template_id, &mut self.metrics);
-                let n = drained.len() as u64;
-                if n > 0 {
-                    self.metrics.record_pending_dropped_n(n);
-                }
-            }
+            self.remove_data_template_owners(&[template_id]);
         }
     }
 
@@ -1107,37 +1118,17 @@ impl IPFixParser {
     /// field_count == 0 signals "withdraw ALL options templates".
     fn withdraw_ipfix_options_template(&mut self, template_id: u16) {
         if template_id == OPTIONS_TEMPLATE_IPFIX_ID {
-            // "Withdraw all options templates" — clear entire options template
-            // cache and drain pending flows only for those template IDs.
-            // Pending flows for data template IDs are left untouched.
-            let ids: Vec<u16> = self
+            let mut ids: Vec<u16> = self
                 .ipfix_options_templates
                 .iter()
                 .map(|(&id, _)| id)
                 .collect();
-            for id in &ids {
-                self.ipfix_options_templates.pop(id);
-                self.evict_from_store(TemplateKind::IpfixOptions, *id);
-            }
-            if let Some(ref mut cache) = self.pending_flows {
-                for &id in &ids {
-                    let drained = cache.drain(id, &mut self.metrics);
-                    let n = drained.len() as u64;
-                    if n > 0 {
-                        self.metrics.record_pending_dropped_n(n);
-                    }
-                }
-            }
+            ids.extend(self.v9_options_templates.iter().map(|(&id, _)| id));
+            ids.sort_unstable();
+            ids.dedup();
+            self.remove_options_template_owners(&ids);
         } else {
-            self.ipfix_options_templates.pop(&template_id);
-            self.evict_from_store(TemplateKind::IpfixOptions, template_id);
-            if let Some(ref mut cache) = self.pending_flows {
-                let drained = cache.drain(template_id, &mut self.metrics);
-                let n = drained.len() as u64;
-                if n > 0 {
-                    self.metrics.record_pending_dropped_n(n);
-                }
-            }
+            self.remove_options_template_owners(&[template_id]);
         }
     }
 }

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -831,124 +831,231 @@ impl HasTemplateId for V9OptionsTemplate {
     }
 }
 
-/// Insert templates into an LRU cache, recording collision/eviction/insertion
-/// metrics. Returns the IDs of any entries the LRU evicted to make room so the
-/// caller can mirror the eviction into the secondary template store.
-fn insert_templates<T: HasTemplateId>(
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IpfixTemplateSlot {
+    IpfixData,
+    IpfixOptions,
+    V9Data,
+    V9Options,
+}
+
+impl IpfixTemplateSlot {
+    const ALL: [Self; 4] = [
+        Self::IpfixData,
+        Self::IpfixOptions,
+        Self::V9Data,
+        Self::V9Options,
+    ];
+
+    fn store_kind(self) -> TemplateKind {
+        match self {
+            Self::IpfixData => TemplateKind::IpfixData,
+            Self::IpfixOptions => TemplateKind::IpfixOptions,
+            Self::V9Data => TemplateKind::IpfixV9Data,
+            Self::V9Options => TemplateKind::IpfixV9Options,
+        }
+    }
+}
+
+/// Remove one physical cache entry and report whether it was still a live owner.
+fn remove_cached_owner<T>(
     cache: &mut LazyLruCache<u16, TemplateWithTtl<Arc<T>>>,
-    templates: &[T],
+    template_id: u16,
+    ttl_config: &Option<TtlConfig>,
+    metrics: &mut CacheMetricsInner,
+) -> bool {
+    let Some(expired) = cache
+        .peek(&template_id)
+        .map(|entry| ttl_config.as_ref().is_some_and(|ttl| entry.is_expired(ttl)))
+    else {
+        return false;
+    };
+
+    cache.pop(&template_id);
+    if expired {
+        metrics.record_expiration();
+        false
+    } else {
+        true
+    }
+}
+
+/// Insert one template and return any different Template ID evicted by the LRU.
+fn insert_template<T: HasTemplateId>(
+    cache: &mut LazyLruCache<u16, TemplateWithTtl<Arc<T>>>,
+    template: &T,
     ttl_enabled: bool,
     metrics: &mut CacheMetricsInner,
-) -> Vec<u16> {
-    let mut evicted_ids = Vec::new();
-    for t in templates {
-        let arc_template = Arc::new(t.clone());
-        let wrapped = TemplateWithTtl::new(arc_template, ttl_enabled);
-        if let Some(existing) = cache.peek(&t.template_id())
-            && existing.template.as_ref() != t
-        {
-            metrics.record_collision();
-        }
-        // push() returns Some in two cases: (1) a different key was LRU-evicted
-        // to make room, or (2) the same key existed and its value was replaced.
-        // Only count case (1) as an eviction.
-        if let Some((evicted_key, _evicted)) = cache.push(t.template_id(), wrapped)
-            && evicted_key != t.template_id()
-        {
-            metrics.record_eviction();
-            evicted_ids.push(evicted_key);
-        }
-        metrics.record_insertion();
+) -> Option<u16> {
+    let template_id = template.template_id();
+    if let Some(existing) = cache.peek(&template_id)
+        && existing.template.as_ref() != template
+    {
+        metrics.record_collision();
     }
-    evicted_ids
+
+    let wrapped = TemplateWithTtl::new(Arc::new(template.clone()), ttl_enabled);
+    let evicted_id = cache
+        .push(template_id, wrapped)
+        .and_then(|(evicted_id, _)| (evicted_id != template_id).then_some(evicted_id));
+    if evicted_id.is_some() {
+        metrics.record_eviction();
+    }
+    metrics.record_insertion();
+    evicted_id
 }
 
 impl IPFixParser {
+    /// Remove every physical owner except the slot receiving the new definition.
+    fn remove_other_template_owners(
+        &mut self,
+        installed_slot: IpfixTemplateSlot,
+        template_id: u16,
+    ) {
+        let mut replaced_live_owner = false;
+        if installed_slot != IpfixTemplateSlot::IpfixData {
+            replaced_live_owner |= remove_cached_owner(
+                &mut self.templates,
+                template_id,
+                &self.ttl_config,
+                &mut self.metrics,
+            );
+        }
+        if installed_slot != IpfixTemplateSlot::IpfixOptions {
+            replaced_live_owner |= remove_cached_owner(
+                &mut self.ipfix_options_templates,
+                template_id,
+                &self.ttl_config,
+                &mut self.metrics,
+            );
+        }
+        if installed_slot != IpfixTemplateSlot::V9Data {
+            replaced_live_owner |= remove_cached_owner(
+                &mut self.v9_templates,
+                template_id,
+                &self.ttl_config,
+                &mut self.metrics,
+            );
+        }
+        if installed_slot != IpfixTemplateSlot::V9Options {
+            replaced_live_owner |= remove_cached_owner(
+                &mut self.v9_options_templates,
+                template_id,
+                &self.ttl_config,
+                &mut self.metrics,
+            );
+        }
+        if replaced_live_owner {
+            self.metrics.record_collision();
+        }
+
+        if self.template_store.is_some() {
+            for slot in IpfixTemplateSlot::ALL {
+                if slot != installed_slot {
+                    self.evict_from_store(slot.store_kind(), template_id);
+                }
+            }
+        }
+    }
+
     /// Add templates to the parser by cloning from slice.
     fn add_ipfix_templates(&mut self, templates: &[Template]) {
         let ttl_enabled = self.ttl_config.is_some();
-        let evicted = insert_templates(
-            &mut self.templates,
-            templates,
-            ttl_enabled,
-            &mut self.metrics,
-        );
-        if self.template_store.is_some() {
-            for t in templates {
+        for template in templates {
+            self.remove_other_template_owners(
+                IpfixTemplateSlot::IpfixData,
+                template.template_id,
+            );
+            let evicted = insert_template(
+                &mut self.templates,
+                template,
+                ttl_enabled,
+                &mut self.metrics,
+            );
+            if self.template_store.is_some() {
                 self.put_to_store(
                     TemplateKind::IpfixData,
-                    t.template_id,
-                    encode_ipfix_template(t),
+                    template.template_id,
+                    encode_ipfix_template(template),
                 );
-            }
-            for id in evicted {
-                self.evict_from_store(TemplateKind::IpfixData, id);
+                if let Some(id) = evicted {
+                    self.evict_from_store(TemplateKind::IpfixData, id);
+                }
             }
         }
     }
 
     fn add_ipfix_options_templates(&mut self, templates: &[OptionsTemplate]) {
         let ttl_enabled = self.ttl_config.is_some();
-        let evicted = insert_templates(
-            &mut self.ipfix_options_templates,
-            templates,
-            ttl_enabled,
-            &mut self.metrics,
-        );
-        if self.template_store.is_some() {
-            for t in templates {
+        for template in templates {
+            self.remove_other_template_owners(
+                IpfixTemplateSlot::IpfixOptions,
+                template.template_id,
+            );
+            let evicted = insert_template(
+                &mut self.ipfix_options_templates,
+                template,
+                ttl_enabled,
+                &mut self.metrics,
+            );
+            if self.template_store.is_some() {
                 self.put_to_store(
                     TemplateKind::IpfixOptions,
-                    t.template_id,
-                    encode_ipfix_options_template(t),
+                    template.template_id,
+                    encode_ipfix_options_template(template),
                 );
-            }
-            for id in evicted {
-                self.evict_from_store(TemplateKind::IpfixOptions, id);
+                if let Some(id) = evicted {
+                    self.evict_from_store(TemplateKind::IpfixOptions, id);
+                }
             }
         }
     }
 
     fn add_v9_templates(&mut self, templates: &[V9Template]) {
         let ttl_enabled = self.ttl_config.is_some();
-        let evicted = insert_templates(
-            &mut self.v9_templates,
-            templates,
-            ttl_enabled,
-            &mut self.metrics,
-        );
-        if self.template_store.is_some() {
-            for t in templates {
+        for template in templates {
+            self.remove_other_template_owners(IpfixTemplateSlot::V9Data, template.template_id);
+            let evicted = insert_template(
+                &mut self.v9_templates,
+                template,
+                ttl_enabled,
+                &mut self.metrics,
+            );
+            if self.template_store.is_some() {
                 self.put_to_store(
                     TemplateKind::IpfixV9Data,
-                    t.template_id,
-                    encode_v9_template(t),
+                    template.template_id,
+                    encode_v9_template(template),
                 );
-            }
-            for id in evicted {
-                self.evict_from_store(TemplateKind::IpfixV9Data, id);
+                if let Some(id) = evicted {
+                    self.evict_from_store(TemplateKind::IpfixV9Data, id);
+                }
             }
         }
     }
 
     fn add_v9_options_templates(&mut self, templates: &[V9OptionsTemplate]) {
         let ttl_enabled = self.ttl_config.is_some();
-        let evicted = insert_templates(
-            &mut self.v9_options_templates,
-            templates,
-            ttl_enabled,
-            &mut self.metrics,
-        );
-        if self.template_store.is_some() {
-            for t in templates {
+        for template in templates {
+            self.remove_other_template_owners(
+                IpfixTemplateSlot::V9Options,
+                template.template_id,
+            );
+            let evicted = insert_template(
+                &mut self.v9_options_templates,
+                template,
+                ttl_enabled,
+                &mut self.metrics,
+            );
+            if self.template_store.is_some() {
                 self.put_to_store(
                     TemplateKind::IpfixV9Options,
-                    t.template_id,
-                    encode_v9_options_template(t),
+                    template.template_id,
+                    encode_v9_options_template(template),
                 );
-            }
-            for id in evicted {
-                self.evict_from_store(TemplateKind::IpfixV9Options, id);
+                if let Some(id) = evicted {
+                    self.evict_from_store(TemplateKind::IpfixV9Options, id);
+                }
             }
         }
     }
@@ -1183,13 +1290,9 @@ impl FlowSetBody {
             ),
             // Parse Data
             _ => {
-                // NOTE: Template ID collision across cache types is possible and
-                // expected when both IPFIX and V9-style templates coexist in
-                // the same parser (the IPFIX parser accepts both flavors).
-                // The lookup order below defines priority: IPFIX templates >
-                // IPFIX options > V9 templates > V9 options. If the same
-                // template ID appears in multiple caches, only the first
-                // match is used and others are silently shadowed.
+                // Definition installation keeps these physical caches disjoint by
+                // Template ID, so this probe order selects representation rather
+                // than resolving competing owners.
 
                 // Try IPFix templates
                 if let Some(template) = crate::variable_versions::get_valid_template(

--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -35,6 +35,7 @@ pub type IPFixFieldPair = (IPFixField, FieldValue);
 pub type IPFixFlowRecord = Vec<IPFixFieldPair>;
 /// Stateful IPFIX parser with LRU template caches and optional pending flow support.
 /// Supports both native IPFIX templates and V9-style templates embedded in IPFIX messages.
+/// All accepted template representations share one logical Template ID namespace.
 #[derive(Debug)]
 pub struct IPFixParser {
     pub(crate) templates: LazyLruCache<TemplateId, TemplateWithTtl<Arc<Template>>>,

--- a/tests/ipfix_template_id_ownership.rs
+++ b/tests/ipfix_template_id_ownership.rs
@@ -44,9 +44,9 @@ fn set(id: u16, body: &[u8]) -> Vec<u8> {
     bytes
 }
 
-fn data_template_body() -> Vec<u8> {
+fn data_template_body(template_id: u16) -> Vec<u8> {
     let mut body = Vec::with_capacity(12);
-    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&template_id.to_be_bytes());
     body.extend_from_slice(&2u16.to_be_bytes());
     body.extend_from_slice(&1u16.to_be_bytes());
     body.extend_from_slice(&4u16.to_be_bytes());
@@ -55,9 +55,9 @@ fn data_template_body() -> Vec<u8> {
     body
 }
 
-fn ipfix_options_template_body() -> Vec<u8> {
+fn ipfix_options_template_body(template_id: u16) -> Vec<u8> {
     let mut body = Vec::with_capacity(14);
-    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&template_id.to_be_bytes());
     body.extend_from_slice(&2u16.to_be_bytes());
     body.extend_from_slice(&1u16.to_be_bytes());
     body.extend_from_slice(&1u16.to_be_bytes());
@@ -67,9 +67,9 @@ fn ipfix_options_template_body() -> Vec<u8> {
     body
 }
 
-fn v9_options_template_body() -> Vec<u8> {
+fn v9_options_template_body(template_id: u16) -> Vec<u8> {
     let mut body = Vec::with_capacity(14);
-    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&template_id.to_be_bytes());
     body.extend_from_slice(&4u16.to_be_bytes());
     body.extend_from_slice(&4u16.to_be_bytes());
     body.extend_from_slice(&1u16.to_be_bytes());
@@ -80,16 +80,37 @@ fn v9_options_template_body() -> Vec<u8> {
 }
 
 fn definition(kind: DefinitionKind) -> Vec<u8> {
+    definition_with_id(kind, TEMPLATE_ID)
+}
+
+fn definition_with_id(kind: DefinitionKind, template_id: u16) -> Vec<u8> {
     match kind {
-        DefinitionKind::IpfixData => set(2, &data_template_body()),
-        DefinitionKind::IpfixOptions => set(3, &ipfix_options_template_body()),
-        DefinitionKind::V9Data => set(0, &data_template_body()),
-        DefinitionKind::V9Options => set(1, &v9_options_template_body()),
+        DefinitionKind::IpfixData => set(2, &data_template_body(template_id)),
+        DefinitionKind::IpfixOptions => set(3, &ipfix_options_template_body(template_id)),
+        DefinitionKind::V9Data => set(0, &data_template_body(template_id)),
+        DefinitionKind::V9Options => set(1, &v9_options_template_body(template_id)),
     }
 }
 
 fn data_set() -> Vec<u8> {
-    set(TEMPLATE_ID, &[0, 0, 0, 1, 0, 0, 0, 2])
+    data_set_with_id(TEMPLATE_ID)
+}
+
+fn data_set_with_id(template_id: u16) -> Vec<u8> {
+    set(template_id, &[0, 0, 0, 1, 0, 0, 0, 2])
+}
+
+fn withdrawal(kind: DefinitionKind, template_id: u16) -> Vec<u8> {
+    let mut body = Vec::with_capacity(6);
+    body.extend_from_slice(&template_id.to_be_bytes());
+    body.extend_from_slice(&0u16.to_be_bytes());
+    match kind {
+        DefinitionKind::IpfixData | DefinitionKind::V9Data => set(2, &body),
+        DefinitionKind::IpfixOptions | DefinitionKind::V9Options => {
+            body.extend_from_slice(&0u16.to_be_bytes());
+            set(3, &body)
+        }
+    }
 }
 
 fn message(sets: &[&[u8]]) -> Vec<u8> {
@@ -125,6 +146,15 @@ fn assert_data_kind(body: &FlowSetBody, expected: DefinitionKind) {
         DefinitionKind::V9Options => matches!(body, FlowSetBody::V9OptionsData(_)),
     };
     assert!(matches, "expected {expected:?}, got {body:?}");
+}
+
+fn assert_no_template(result: &netflow_parser::ParseResult) {
+    let packet = parsed_ipfix(result);
+    assert!(
+        matches!(packet.flowsets[0].body, FlowSetBody::NoTemplate(_)),
+        "expected missing template, got {:?}",
+        packet.flowsets[0].body
+    );
 }
 
 #[test]
@@ -213,4 +243,76 @@ fn expired_opposite_ipfix_kind_is_not_counted_as_a_collision() {
     assert_eq!(cache.metrics.expired, 1);
     assert_eq!(cache.metrics.collisions, 0);
     assert_eq!(cache.metrics.evictions, 0);
+}
+
+#[test]
+fn native_individual_withdrawal_removes_v9_style_owner() {
+    for owner in [DefinitionKind::V9Data, DefinitionKind::V9Options] {
+        let mut parser = NetflowParser::default();
+        let template = definition(owner);
+        parsed_ipfix(&parser.parse_bytes(&message(&[&template])));
+        assert!(parser.has_ipfix_template(TEMPLATE_ID));
+
+        let withdrawal = withdrawal(owner, TEMPLATE_ID);
+        parsed_ipfix(&parser.parse_bytes(&message(&[&withdrawal])));
+        assert!(!parser.has_ipfix_template(TEMPLATE_ID));
+
+        let data = data_set();
+        assert_no_template(&parser.parse_bytes(&message(&[&data])));
+    }
+}
+
+#[test]
+fn native_withdraw_all_removes_both_encodings_of_the_template_class() {
+    for (withdrawn, survivor) in [
+        (
+            [DefinitionKind::IpfixData, DefinitionKind::V9Data],
+            DefinitionKind::V9Options,
+        ),
+        (
+            [DefinitionKind::IpfixOptions, DefinitionKind::V9Options],
+            DefinitionKind::V9Data,
+        ),
+    ] {
+        let store = Arc::new(InMemoryTemplateStore::new());
+        let mut parser = NetflowParser::builder()
+            .with_template_store(store.clone())
+            .with_template_store_scope(STORE_SCOPE)
+            .build()
+            .unwrap();
+        let definitions = [
+            definition_with_id(withdrawn[0], 256),
+            definition_with_id(withdrawn[1], 257),
+            definition_with_id(survivor, 258),
+        ];
+        for definition in &definitions {
+            parsed_ipfix(&parser.parse_bytes(&message(&[definition])));
+        }
+        assert_eq!(parser.ipfix_cache_info().current_size, 3);
+
+        let withdraw_all_id = match withdrawn[0] {
+            DefinitionKind::IpfixData => 2,
+            DefinitionKind::IpfixOptions => 3,
+            _ => unreachable!(),
+        };
+        let withdraw_all = withdrawal(withdrawn[0], withdraw_all_id);
+        parsed_ipfix(&parser.parse_bytes(&message(&[&withdraw_all])));
+
+        assert!(!parser.has_ipfix_template(256));
+        assert!(!parser.has_ipfix_template(257));
+        assert!(parser.has_ipfix_template(258));
+        assert_eq!(parser.ipfix_cache_info().current_size, 1);
+
+        for (kind, template_id) in [(withdrawn[0], 256), (withdrawn[1], 257)] {
+            let key = TemplateStoreKey::new(STORE_SCOPE, kind.store_kind(), template_id);
+            assert!(store.get(&key).unwrap().is_none());
+            let data = data_set_with_id(template_id);
+            assert_no_template(&parser.parse_bytes(&message(&[&data])));
+        }
+        let survivor_key = TemplateStoreKey::new(STORE_SCOPE, survivor.store_kind(), 258);
+        assert!(store.get(&survivor_key).unwrap().is_some());
+        let data = data_set_with_id(258);
+        let result = parser.parse_bytes(&message(&[&data]));
+        assert_data_kind(&parsed_ipfix(&result).flowsets[0].body, survivor);
+    }
 }

--- a/tests/ipfix_template_id_ownership.rs
+++ b/tests/ipfix_template_id_ownership.rs
@@ -1,0 +1,216 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{
+    InMemoryTemplateStore, NetflowPacket, NetflowParser, TemplateKind, TemplateStore,
+    TemplateStoreKey, TtlConfig,
+};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+const TEMPLATE_ID: u16 = 256;
+const STORE_SCOPE: &str = "ipfix-template-owner";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DefinitionKind {
+    IpfixData,
+    IpfixOptions,
+    V9Data,
+    V9Options,
+}
+
+const DEFINITION_KINDS: [DefinitionKind; 4] = [
+    DefinitionKind::IpfixData,
+    DefinitionKind::IpfixOptions,
+    DefinitionKind::V9Data,
+    DefinitionKind::V9Options,
+];
+
+impl DefinitionKind {
+    fn store_kind(self) -> TemplateKind {
+        match self {
+            Self::IpfixData => TemplateKind::IpfixData,
+            Self::IpfixOptions => TemplateKind::IpfixOptions,
+            Self::V9Data => TemplateKind::IpfixV9Data,
+            Self::V9Options => TemplateKind::IpfixV9Options,
+        }
+    }
+}
+
+fn set(id: u16, body: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(4 + body.len());
+    bytes.extend_from_slice(&id.to_be_bytes());
+    bytes.extend_from_slice(&u16::try_from(4 + body.len()).unwrap().to_be_bytes());
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn data_template_body() -> Vec<u8> {
+    let mut body = Vec::with_capacity(12);
+    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    body.extend_from_slice(&1u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body
+}
+
+fn ipfix_options_template_body() -> Vec<u8> {
+    let mut body = Vec::with_capacity(14);
+    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    body.extend_from_slice(&1u16.to_be_bytes());
+    body.extend_from_slice(&1u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body
+}
+
+fn v9_options_template_body() -> Vec<u8> {
+    let mut body = Vec::with_capacity(14);
+    body.extend_from_slice(&TEMPLATE_ID.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body.extend_from_slice(&1u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body.extend_from_slice(&2u16.to_be_bytes());
+    body.extend_from_slice(&4u16.to_be_bytes());
+    body
+}
+
+fn definition(kind: DefinitionKind) -> Vec<u8> {
+    match kind {
+        DefinitionKind::IpfixData => set(2, &data_template_body()),
+        DefinitionKind::IpfixOptions => set(3, &ipfix_options_template_body()),
+        DefinitionKind::V9Data => set(0, &data_template_body()),
+        DefinitionKind::V9Options => set(1, &v9_options_template_body()),
+    }
+}
+
+fn data_set() -> Vec<u8> {
+    set(TEMPLATE_ID, &[0, 0, 0, 1, 0, 0, 0, 2])
+}
+
+fn message(sets: &[&[u8]]) -> Vec<u8> {
+    let body_len = sets.iter().map(|set| set.len()).sum::<usize>();
+    let mut bytes = Vec::with_capacity(16 + body_len);
+    bytes.extend_from_slice(&10u16.to_be_bytes());
+    bytes.extend_from_slice(&u16::try_from(16 + body_len).unwrap().to_be_bytes());
+    bytes.extend_from_slice(&0u32.to_be_bytes());
+    bytes.extend_from_slice(&0u32.to_be_bytes());
+    bytes.extend_from_slice(&42u32.to_be_bytes());
+    for set in sets {
+        bytes.extend_from_slice(set);
+    }
+    bytes
+}
+
+fn parsed_ipfix(
+    result: &netflow_parser::ParseResult,
+) -> &netflow_parser::variable_versions::ipfix::Ipfix {
+    assert!(result.error.is_none(), "{:?}", result.error);
+    assert_eq!(result.packets.len(), 1);
+    let NetflowPacket::IPFix(packet) = &result.packets[0] else {
+        panic!("expected IPFIX message");
+    };
+    packet
+}
+
+fn assert_data_kind(body: &FlowSetBody, expected: DefinitionKind) {
+    let matches = match expected {
+        DefinitionKind::IpfixData => matches!(body, FlowSetBody::Data(_)),
+        DefinitionKind::IpfixOptions => matches!(body, FlowSetBody::OptionsData(_)),
+        DefinitionKind::V9Data => matches!(body, FlowSetBody::V9Data(_)),
+        DefinitionKind::V9Options => matches!(body, FlowSetBody::V9OptionsData(_)),
+    };
+    assert!(matches, "expected {expected:?}, got {body:?}");
+}
+
+#[test]
+fn last_definition_owns_the_id_across_all_ipfix_template_kinds() {
+    for first in DEFINITION_KINDS {
+        for last in DEFINITION_KINDS {
+            if first == last {
+                continue;
+            }
+
+            let first_definition = definition(first);
+            let last_definition = definition(last);
+            let data = data_set();
+            let mut parser = NetflowParser::default();
+            let result =
+                parser.parse_bytes(&message(&[&first_definition, &last_definition, &data]));
+            let packet = parsed_ipfix(&result);
+            assert_data_kind(&packet.flowsets[2].body, last);
+
+            let cache = parser.ipfix_cache_info();
+            assert_eq!(cache.current_size, 1, "{first:?} -> {last:?}");
+            assert_eq!(cache.num_caches, 4);
+            assert_eq!(cache.metrics.insertions, 2);
+            assert_eq!(cache.metrics.collisions, 1, "{first:?} -> {last:?}");
+            assert_eq!(cache.metrics.evictions, 0);
+        }
+    }
+}
+
+#[test]
+fn template_store_retains_only_the_last_ipfix_template_kind() {
+    for first in DEFINITION_KINDS {
+        for last in DEFINITION_KINDS {
+            if first == last {
+                continue;
+            }
+
+            let store = Arc::new(InMemoryTemplateStore::new());
+            let builder = NetflowParser::builder()
+                .with_template_store(store.clone())
+                .with_template_store_scope(STORE_SCOPE);
+            let mut writer = builder.clone().build().unwrap();
+
+            let first_definition = definition(first);
+            let last_definition = definition(last);
+            let result = writer.parse_bytes(&message(&[&first_definition, &last_definition]));
+            parsed_ipfix(&result);
+
+            for candidate in DEFINITION_KINDS {
+                let key =
+                    TemplateStoreKey::new(STORE_SCOPE, candidate.store_kind(), TEMPLATE_ID);
+                assert_eq!(
+                    store.get(&key).unwrap().is_some(),
+                    candidate == last,
+                    "{first:?} -> {last:?}: unexpected store state for {candidate:?}"
+                );
+            }
+
+            let mut reader = builder.build().unwrap();
+            let data = data_set();
+            let result = reader.parse_bytes(&message(&[&data]));
+            let packet = parsed_ipfix(&result);
+            assert_data_kind(&packet.flowsets[0].body, last);
+            assert_eq!(reader.ipfix_cache_info().current_size, 1);
+        }
+    }
+}
+
+#[test]
+fn expired_opposite_ipfix_kind_is_not_counted_as_a_collision() {
+    let mut parser = NetflowParser::builder()
+        .with_ipfix_ttl(TtlConfig::new(Duration::from_millis(1)))
+        .build()
+        .unwrap();
+
+    let first_definition = definition(DefinitionKind::IpfixData);
+    parsed_ipfix(&parser.parse_bytes(&message(&[&first_definition])));
+    thread::sleep(Duration::from_millis(5));
+
+    let last_definition = definition(DefinitionKind::V9Options);
+    parsed_ipfix(&parser.parse_bytes(&message(&[&last_definition])));
+
+    let cache = parser.ipfix_cache_info();
+    assert_eq!(cache.current_size, 1);
+    assert_eq!(cache.metrics.insertions, 2);
+    assert_eq!(cache.metrics.expired, 1);
+    assert_eq!(cache.metrics.collisions, 0);
+    assert_eq!(cache.metrics.evictions, 0);
+}

--- a/tests/pcap_integration.rs
+++ b/tests/pcap_integration.rs
@@ -130,7 +130,7 @@ fn test_pcap_template_caching() {
 
     // IPFIX.pcap should have exactly 15 templates (IDs 256-270)
     assert_eq!(
-        ipfix_info.current_size, 17,
+        ipfix_info.current_size, 15,
         "Expected exact IPFIX template cache size"
     );
     assert_eq!(
@@ -179,7 +179,7 @@ fn test_pcap_cache_metrics() {
     let metrics = &ipfix_info.metrics;
 
     assert_eq!(
-        ipfix_info.current_size, 17,
+        ipfix_info.current_size, 15,
         "Expected exact IPFIX template cache size"
     );
     assert_eq!(metrics.hits, 5754, "Expected exact cache hit count");


### PR DESCRIPTION
## What was wrong

The IPFIX parser accepts four template encodings:

- native Data templates
- native Options templates
- NetFlow v9-style Data templates carried through the IPFIX parser
- NetFlow v9-style Options templates carried through the IPFIX parser

These were stored in four independent caches. If the same Template ID was defined under two different encodings, both definitions remained cached. Data lookup used a fixed cache priority, so an older higher-priority definition could silently override the later wire definition.

The bundled IPFIX capture demonstrates the accounting symptom: it contains 15 unique Template IDs, but the parser retained 17 physical cache entries because IDs 262 and 263 were each defined as Options, then Data, then Options templates.

## Protocol basis

RFC 7011 sections 3.4.1 and 3.4.2 require Templates and Options Templates to use one Template ID namespace within a Transport Session and Observation Domain. For UDP, section 8.4 says that a new different definition replaces the previous definition.

The v9-style encodings accepted by this parser follow the same logical ownership rule: one active definition per Template ID.

## What this changes

- The last valid definition in wire order becomes the sole in-memory owner of its Template ID.
- The other three physical cache entries are removed before installation.
- A live cross-kind replacement records one collision.
- An expired opposite owner records expiration instead of collision.
- Superseded keys are removed from the optional TemplateStore before the new owner is written.
- Existing cache capacities and public APIs remain unchanged.
- Data-record lookup performs exactly the same work as before; cleanup runs only when a template definition is received.

The store removals are intentionally unconditional when a store is configured. An empty local cache does not prove that a persisted key is absent after restart or earlier divergence.

## Compatibility

This corrects observable behavior for streams that reuse one Template ID across template encodings:

- cache size now reports one entry per logical Template ID
- the last accepted definition determines decoding
- collision and expiration metrics include cross-kind replacement

A store created by older code may already contain conflicting physical keys. Existing read-through priority remains unchanged until the next wire definition, which cleans the conflicting keys. General store migration and transactional store behavior are not changed here.

## Tests

The regression suite covers:

- all 12 ordered transitions across the four accepted template encodings
- decoded record kind after each transition
- logical cache size and collision, expiration, insertion, and eviction metrics
- persistent-store cleanup and fresh-parser restoration for all 12 transitions
- expired opposite-owner replacement
- the bundled real IPFIX capture, including the corrected 15-template cache size

The focused tests pass with default and no-default features. The complete project checks pass: formatting, Clippy, build, unit and integration tests, documentation tests, README synchronization, and benchmark compilation.