### PR TITLE
feat: report scoped source removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,33 @@ let mut scoped = RouterScopedParser::<CustomKey>::new();
 
 **For standard NetFlow/IPFIX deployments, use `AutoScopedParser` instead.**
 
+#### Observing Implicit Source Removal
+
+Scoped parsers bound memory by removing sources during capacity pressure,
+idle pruning, or a capacity reduction. The existing methods keep their original
+signatures and discard detailed reports. Use the corresponding
+`*_with_reporter` companion when application state must be removed at the same
+time:
+
+```rust,ignore
+use netflow_parser::AutoScopedParser;
+
+let mut parser = AutoScopedParser::new().with_max_sources(10_000)?;
+let result = parser.parse_from_source_with_reporter(source, &data, &mut |removal| {
+    remove_application_state(&removal.source, removal.cause);
+    Ok(())
+});
+```
+
+Companions are available for parse, iterator, idle-prune, and max-source-resize
+operations on both `AutoScopedParser` and `RouterScopedParser`. Each report is
+delivered synchronously after the source is detached. Reporting does not add,
+remove, or otherwise change `TemplateStore` operations performed by the existing
+methods. Reporter errors and panics do not interrupt parser state changes and are
+counted in `source_removal_metrics()` together with removal causes. Explicit
+source-removal methods transfer the parser to the caller and do not emit an
+implicit-removal report.
+
 #### Custom Parser Configuration
 
 Configure parsers with custom settings:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,9 @@ fn count_valid_templates<T>(
 
 // Re-export scoped parser types for convenience
 pub use scoped_parser::{
-    AutoScopedParser, DEFAULT_MAX_SOURCES, IpfixSourceKey, RouterScopedParser, ScopingInfo,
-    V9SourceKey, extract_scoping_info,
+    AutoScopedParser, AutoSourceKey, DEFAULT_MAX_SOURCES, IpfixSourceKey, RouterScopedParser,
+    ScopingInfo, SourceRemoval, SourceRemovalCause, SourceRemovalMetrics,
+    SourceRemovalReporterError, V9SourceKey, extract_scoping_info,
 };
 
 // Re-export template event types for convenience

--- a/src/scoped_parser.rs
+++ b/src/scoped_parser.rs
@@ -13,6 +13,12 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::time::{Duration, Instant};
 
+mod source_removal;
+pub use source_removal::{
+    SourceRemoval, SourceRemovalCause, SourceRemovalMetrics, SourceRemovalReporterError,
+};
+use source_removal::{ignore_source_removal, report_source_removal};
+
 /// Default maximum number of sources tracked by scoped parsers.
 /// Prevents unbounded memory growth from spoofed source addresses.
 pub const DEFAULT_MAX_SOURCES: usize = 10_000;
@@ -75,6 +81,8 @@ pub struct RouterScopedParser<K: Hash + Eq> {
     parser_builder: Option<NetflowParserBuilder>,
     /// Maximum number of sources to track.
     max_sources: usize,
+    /// Aggregate metrics retained after child parsers are removed.
+    source_removal_metrics: SourceRemovalMetrics,
 }
 
 impl<K: Hash + Eq> Default for RouterScopedParser<K> {
@@ -95,6 +103,7 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
             ),
             parser_builder: None,
             max_sources: DEFAULT_MAX_SOURCES,
+            source_removal_metrics: SourceRemovalMetrics::default(),
         }
     }
 
@@ -131,6 +140,7 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
             ),
             parser_builder: Some(builder),
             max_sources: DEFAULT_MAX_SOURCES,
+            source_removal_metrics: SourceRemovalMetrics::default(),
         })
     }
 
@@ -143,11 +153,45 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
     /// # Errors
     ///
     /// Returns `ConfigError::InvalidMaxSources` if `max` is 0.
-    pub fn with_max_sources(mut self, max: usize) -> Result<Self, ConfigError> {
+    pub fn with_max_sources(self, max: usize) -> Result<Self, ConfigError> {
+        let mut reporter = ignore_source_removal::<K>;
+        self.with_max_sources_and_reporter(max, &mut reporter)
+    }
+
+    /// Set the maximum number of sources and report every source removed by
+    /// reducing the capacity.
+    ///
+    /// Reporting completes synchronously before this method returns.
+    /// Reporter errors and panics are isolated and counted in
+    /// [`source_removal_metrics`](Self::source_removal_metrics).
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidMaxSources` if `max` is 0.
+    pub fn with_max_sources_and_reporter<F>(
+        mut self,
+        max: usize,
+        reporter: &mut F,
+    ) -> Result<Self, ConfigError>
+    where
+        F: FnMut(&SourceRemoval<K>) -> Result<(), SourceRemovalReporterError>,
+    {
         if max == 0 {
             return Err(ConfigError::InvalidMaxSources(0));
         }
         self.max_sources = max;
+        while self.parsers.len() > max {
+            let Some((source, (parser, _))) = self.parsers.pop_lru() else {
+                break;
+            };
+            drop(parser);
+            report_source_removal(
+                source,
+                SourceRemovalCause::CapacityReduced,
+                &mut self.source_removal_metrics,
+                reporter,
+            );
+        }
         self.parsers
             .resize(NonZeroUsize::new(max).expect("max is non-zero"));
         Ok(self)
@@ -170,6 +214,21 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
     pub fn parse_from_source(&mut self, source: K, data: &[u8]) -> ParseResult
     where
         K: Clone,
+    {
+        let mut reporter = ignore_source_removal::<K>;
+        self.parse_from_source_with_reporter(source, data, &mut reporter)
+    }
+
+    /// Parse data and synchronously report any source displaced by capacity pressure.
+    pub fn parse_from_source_with_reporter<F>(
+        &mut self,
+        source: K,
+        data: &[u8],
+        reporter: &mut F,
+    ) -> ParseResult
+    where
+        K: Clone,
+        F: FnMut(&SourceRemoval<K>) -> Result<(), SourceRemovalReporterError>,
     {
         // If the source already exists, LRU get promotes it and we parse.
         if let Some((parser, last_seen)) = self.parsers.get_mut(&source) {
@@ -195,7 +254,17 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
         };
 
         let now = Instant::now();
-        self.parsers.push(source.clone(), (p, now));
+        if let Some((removed_source, (removed_parser, _))) =
+            self.parsers.push(source.clone(), (p, now))
+        {
+            drop(removed_parser);
+            report_source_removal(
+                removed_source,
+                SourceRemovalCause::CapacityPressure,
+                &mut self.source_removal_metrics,
+                reporter,
+            );
+        }
         // The entry we just pushed is guaranteed to exist; get_mut promotes it.
         let (parser, _) = self.parsers.get_mut(&source).expect("just inserted");
         parser.parse_bytes(data)
@@ -218,9 +287,31 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
         &'a mut self,
         source: K,
         data: &'a [u8],
-    ) -> Result<impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a, NetflowError>
+    ) -> Result<
+        impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a + use<'a, K>,
+        NetflowError,
+    >
     where
         K: Clone,
+    {
+        let mut reporter = ignore_source_removal::<K>;
+        self.iter_packets_from_source_with_reporter(source, data, &mut reporter)
+    }
+
+    /// Iterate over packets and synchronously report any source displaced by
+    /// capacity pressure before the iterator is returned.
+    pub fn iter_packets_from_source_with_reporter<'a, F>(
+        &'a mut self,
+        source: K,
+        data: &'a [u8],
+        reporter: &mut F,
+    ) -> Result<
+        impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a + use<'a, K, F>,
+        NetflowError,
+    >
+    where
+        K: Clone,
+        F: FnMut(&SourceRemoval<K>) -> Result<(), SourceRemovalReporterError>,
     {
         // If the source already exists, promote it in the LRU and return iterator.
         // Note: contains() + get_mut() is intentional — get_mut() borrows self.parsers
@@ -246,7 +337,17 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
         };
 
         let now = Instant::now();
-        self.parsers.push(source.clone(), (p, now));
+        if let Some((removed_source, (removed_parser, _))) =
+            self.parsers.push(source.clone(), (p, now))
+        {
+            drop(removed_parser);
+            report_source_removal(
+                removed_source,
+                SourceRemovalCause::CapacityPressure,
+                &mut self.source_removal_metrics,
+                reporter,
+            );
+        }
         let (parser, _) = self.parsers.get_mut(&source).expect("just inserted");
         Ok(parser.iter_packets(data))
     }
@@ -258,6 +359,20 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
     where
         K: Clone,
     {
+        let mut reporter = ignore_source_removal::<K>;
+        self.prune_idle_sources_with_reporter(older_than, &mut reporter)
+    }
+
+    /// Remove idle sources and synchronously report every removal.
+    pub fn prune_idle_sources_with_reporter<F>(
+        &mut self,
+        older_than: Duration,
+        reporter: &mut F,
+    ) -> usize
+    where
+        K: Clone,
+        F: FnMut(&SourceRemoval<K>) -> Result<(), SourceRemovalReporterError>,
+    {
         let now = Instant::now();
         let keys_to_remove: Vec<K> = self
             .parsers
@@ -265,11 +380,25 @@ impl<K: Hash + Eq> RouterScopedParser<K> {
             .filter(|(_, (_, last_seen))| now.duration_since(*last_seen) >= older_than)
             .map(|(k, _)| k.clone())
             .collect();
-        let count = keys_to_remove.len();
+        let mut count = 0;
         for key in keys_to_remove {
-            self.parsers.pop(&key);
+            if let Some((source, (parser, _))) = self.parsers.pop_entry(&key) {
+                drop(parser);
+                report_source_removal(
+                    source,
+                    SourceRemovalCause::Idle,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+                count += 1;
+            }
         }
         count
+    }
+
+    /// Return aggregate implicit source-removal metrics.
+    pub fn source_removal_metrics(&self) -> SourceRemovalMetrics {
+        self.source_removal_metrics
     }
 
     /// Get statistics for a specific source's template cache.
@@ -394,6 +523,18 @@ pub struct V9SourceKey {
     pub source_id: u32,
 }
 
+/// Exact source identity used by [`AutoScopedParser`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AutoSourceKey {
+    /// IPFIX exporter address and Observation Domain ID.
+    Ipfix(IpfixSourceKey),
+    /// NetFlow v9 exporter address and Source ID.
+    V9(V9SourceKey),
+    /// NetFlow v5/v7 exporter address.
+    Legacy(SocketAddr),
+}
+
 /// Extract scoping information from a NetFlow packet header without full parsing.
 ///
 /// This function performs a lightweight parse of just the packet header to extract
@@ -511,6 +652,8 @@ pub struct AutoScopedParser {
     parser_builder: Option<NetflowParserBuilder>,
     /// Maximum number of sources to track across all caches.
     max_sources: usize,
+    /// Aggregate metrics retained after child parsers are removed.
+    source_removal_metrics: SourceRemovalMetrics,
 }
 
 impl Default for AutoScopedParser {
@@ -532,6 +675,7 @@ impl AutoScopedParser {
             legacy_parsers: LruCache::new(cap),
             parser_builder: None,
             max_sources: DEFAULT_MAX_SOURCES,
+            source_removal_metrics: SourceRemovalMetrics::default(),
         }
     }
 
@@ -569,6 +713,7 @@ impl AutoScopedParser {
             legacy_parsers: LruCache::new(cap),
             parser_builder: Some(builder),
             max_sources: DEFAULT_MAX_SOURCES,
+            source_removal_metrics: SourceRemovalMetrics::default(),
         })
     }
 
@@ -581,15 +726,67 @@ impl AutoScopedParser {
     /// # Errors
     ///
     /// Returns `ConfigError::InvalidMaxSources` if `max` is 0.
-    pub fn with_max_sources(mut self, max: usize) -> Result<Self, ConfigError> {
+    pub fn with_max_sources(self, max: usize) -> Result<Self, ConfigError> {
+        let mut reporter = ignore_source_removal::<AutoSourceKey>;
+        self.with_max_sources_and_reporter(max, &mut reporter)
+    }
+
+    /// Set the global source limit and report every source removed by reducing it.
+    ///
+    /// Reporting completes synchronously before this method returns.
+    /// Reporter errors and panics are isolated and counted in
+    /// [`source_removal_metrics`](Self::source_removal_metrics).
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidMaxSources` if `max` is 0.
+    pub fn with_max_sources_and_reporter<F>(
+        mut self,
+        max: usize,
+        reporter: &mut F,
+    ) -> Result<Self, ConfigError>
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
         if max == 0 {
             return Err(ConfigError::InvalidMaxSources(0));
         }
         self.max_sources = max;
-        // Size each per-protocol LRU cache to max. The global cross-cache
-        // eviction at `source_count() >= max_sources` enforces the true total
-        // limit; individual caches are capped so their internal LRU eviction
-        // doesn't fire before the global policy.
+        while self.ipfix_parsers.len() > max {
+            if let Some((source, (parser, _))) = self.ipfix_parsers.pop_lru() {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::Ipfix(source),
+                    SourceRemovalCause::CapacityReduced,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+            }
+        }
+        while self.v9_parsers.len() > max {
+            if let Some((source, (parser, _))) = self.v9_parsers.pop_lru() {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::V9(source),
+                    SourceRemovalCause::CapacityReduced,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+            }
+        }
+        while self.legacy_parsers.len() > max {
+            if let Some((source, (parser, _))) = self.legacy_parsers.pop_lru() {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::Legacy(source),
+                    SourceRemovalCause::CapacityReduced,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+            }
+        }
+        // Keep every physical cache at the global limit. The cross-cache
+        // pressure path below enforces the total source count.
         let cap = NonZeroUsize::new(max).expect("max is non-zero");
         self.ipfix_parsers.resize(cap);
         self.v9_parsers.resize(cap);
@@ -626,7 +823,21 @@ impl AutoScopedParser {
     /// let packets = parser.parse_from_source(source, &data);
     /// ```
     pub fn parse_from_source(&mut self, source: SocketAddr, data: &[u8]) -> ParseResult {
-        let parser = match self.get_or_create_parser(source, data) {
+        let mut reporter = ignore_source_removal::<AutoSourceKey>;
+        self.parse_from_source_with_reporter(source, data, &mut reporter)
+    }
+
+    /// Parse data and synchronously report any source displaced by capacity pressure.
+    pub fn parse_from_source_with_reporter<F>(
+        &mut self,
+        source: SocketAddr,
+        data: &[u8],
+        reporter: &mut F,
+    ) -> ParseResult
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
+        let parser = match self.get_or_create_parser(source, data, reporter) {
             Ok(p) => p,
             Err(e) => {
                 return ParseResult {
@@ -655,9 +866,29 @@ impl AutoScopedParser {
         &'a mut self,
         source: SocketAddr,
         data: &'a [u8],
-    ) -> Result<impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a, NetflowError>
+    ) -> Result<
+        impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a + use<'a>,
+        NetflowError,
+    > {
+        let mut reporter = ignore_source_removal::<AutoSourceKey>;
+        self.iter_packets_from_source_with_reporter(source, data, &mut reporter)
+    }
+
+    /// Iterate over packets and synchronously report any source displaced by
+    /// capacity pressure before the iterator is returned.
+    pub fn iter_packets_from_source_with_reporter<'a, F>(
+        &'a mut self,
+        source: SocketAddr,
+        data: &'a [u8],
+        reporter: &mut F,
+    ) -> Result<
+        impl Iterator<Item = Result<NetflowPacket, NetflowError>> + 'a + use<'a, F>,
+        NetflowError,
+    >
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
     {
-        let parser = self.get_or_create_parser(source, data)?;
+        let parser = self.get_or_create_parser(source, data, reporter)?;
         Ok(parser.iter_packets(data))
     }
 
@@ -665,6 +896,19 @@ impl AutoScopedParser {
     ///
     /// Returns the number of sources pruned.
     pub fn prune_idle_sources(&mut self, older_than: Duration) -> usize {
+        let mut reporter = ignore_source_removal::<AutoSourceKey>;
+        self.prune_idle_sources_with_reporter(older_than, &mut reporter)
+    }
+
+    /// Remove idle sources and synchronously report every removal.
+    pub fn prune_idle_sources_with_reporter<F>(
+        &mut self,
+        older_than: Duration,
+        reporter: &mut F,
+    ) -> usize
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
         let now = Instant::now();
 
         let ipfix_keys: Vec<IpfixSourceKey> = self
@@ -688,19 +932,51 @@ impl AutoScopedParser {
             .map(|(k, _)| *k)
             .collect();
 
-        let count = ipfix_keys.len() + v9_keys.len() + legacy_keys.len();
+        let mut count = 0;
 
         for key in ipfix_keys {
-            self.ipfix_parsers.pop(&key);
+            if let Some((source, (parser, _))) = self.ipfix_parsers.pop_entry(&key) {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::Ipfix(source),
+                    SourceRemovalCause::Idle,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+                count += 1;
+            }
         }
         for key in v9_keys {
-            self.v9_parsers.pop(&key);
+            if let Some((source, (parser, _))) = self.v9_parsers.pop_entry(&key) {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::V9(source),
+                    SourceRemovalCause::Idle,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+                count += 1;
+            }
         }
         for key in legacy_keys {
-            self.legacy_parsers.pop(&key);
+            if let Some((source, (parser, _))) = self.legacy_parsers.pop_entry(&key) {
+                drop(parser);
+                report_source_removal(
+                    AutoSourceKey::Legacy(source),
+                    SourceRemovalCause::Idle,
+                    &mut self.source_removal_metrics,
+                    reporter,
+                );
+                count += 1;
+            }
         }
 
         count
+    }
+
+    /// Return aggregate implicit source-removal metrics.
+    pub fn source_removal_metrics(&self) -> SourceRemovalMetrics {
+        self.source_removal_metrics
     }
 
     /// Get the total number of registered sources across all scoping types.
@@ -803,11 +1079,15 @@ impl AutoScopedParser {
     }
 
     /// Get or create a parser for the given source, using LRU eviction when at capacity.
-    fn get_or_create_parser(
+    fn get_or_create_parser<F>(
         &mut self,
         source: SocketAddr,
         data: &[u8],
-    ) -> Result<&mut NetflowParser, NetflowError> {
+        reporter: &mut F,
+    ) -> Result<&mut NetflowParser, NetflowError>
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
         let scoping = extract_scoping_info(data);
         let is_new = match &scoping {
             ScopingInfo::IPFix {
@@ -824,11 +1104,8 @@ impl AutoScopedParser {
             ScopingInfo::Unknown => false, // malformed packets don't create sources
         };
 
-        // When at capacity with a new source, evict the LRU entry from the
-        // appropriate cache. Each cache has its own capacity managed by LRU,
-        // but we also enforce a total cross-cache limit.
         if is_new && self.source_count() >= self.max_sources {
-            self.evict_global_lru();
+            self.evict_global_lru(reporter);
         }
 
         let builder = self.parser_builder.as_ref();
@@ -890,7 +1167,10 @@ impl AutoScopedParser {
 
     /// Evict the globally least-recently-used entry across all three caches.
     /// Uses O(1) peek at the LRU entry of each cache, then pops from the oldest.
-    fn evict_global_lru(&mut self) {
+    fn evict_global_lru<F>(&mut self, reporter: &mut F)
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
         let ipfix_ts = self.ipfix_parsers.peek_lru().map(|(_, (_, ts))| *ts);
         let v9_ts = self.v9_parsers.peek_lru().map(|(_, (_, ts))| *ts);
         let legacy_ts = self.legacy_parsers.peek_lru().map(|(_, (_, ts))| *ts);
@@ -919,24 +1199,44 @@ impl AutoScopedParser {
             })
             .map(|(kind, _, _)| *kind);
 
-        // Pop the LRU entry. If a TemplateStore is configured, clear the
-        // evicted parser's templates from the store *before* dropping it —
-        // otherwise its scope's keys would linger forever, accumulating
-        // monotonically across source churn (no per-scope wipe API exists
-        // on the trait). V5/V7 (Legacy) parsers have no templates.
+        // Preserve the existing pressure-eviction behavior: clear the evicted
+        // AutoScoped child's protocol templates before dropping it. Other
+        // removal paths deliberately retain their pre-existing behavior.
         match oldest {
             Some(MapKind::Ipfix) => {
-                if let Some((_, (mut parser, _))) = self.ipfix_parsers.pop_lru() {
+                if let Some((source, (mut parser, _))) = self.ipfix_parsers.pop_lru() {
                     parser.clear_ipfix_templates();
+                    drop(parser);
+                    report_source_removal(
+                        AutoSourceKey::Ipfix(source),
+                        SourceRemovalCause::CapacityPressure,
+                        &mut self.source_removal_metrics,
+                        reporter,
+                    );
                 }
             }
             Some(MapKind::V9) => {
-                if let Some((_, (mut parser, _))) = self.v9_parsers.pop_lru() {
+                if let Some((source, (mut parser, _))) = self.v9_parsers.pop_lru() {
                     parser.clear_v9_templates();
+                    drop(parser);
+                    report_source_removal(
+                        AutoSourceKey::V9(source),
+                        SourceRemovalCause::CapacityPressure,
+                        &mut self.source_removal_metrics,
+                        reporter,
+                    );
                 }
             }
             Some(MapKind::Legacy) => {
-                self.legacy_parsers.pop_lru();
+                if let Some((source, (parser, _))) = self.legacy_parsers.pop_lru() {
+                    drop(parser);
+                    report_source_removal(
+                        AutoSourceKey::Legacy(source),
+                        SourceRemovalCause::CapacityPressure,
+                        &mut self.source_removal_metrics,
+                        reporter,
+                    );
+                }
             }
             None => {}
         }

--- a/src/scoped_parser.rs
+++ b/src/scoped_parser.rs
@@ -752,38 +752,17 @@ impl AutoScopedParser {
             return Err(ConfigError::InvalidMaxSources(0));
         }
         self.max_sources = max;
-        while self.ipfix_parsers.len() > max {
-            if let Some((source, (parser, _))) = self.ipfix_parsers.pop_lru() {
-                drop(parser);
-                report_source_removal(
-                    AutoSourceKey::Ipfix(source),
-                    SourceRemovalCause::CapacityReduced,
-                    &mut self.source_removal_metrics,
-                    reporter,
-                );
-            }
-        }
-        while self.v9_parsers.len() > max {
-            if let Some((source, (parser, _))) = self.v9_parsers.pop_lru() {
-                drop(parser);
-                report_source_removal(
-                    AutoSourceKey::V9(source),
-                    SourceRemovalCause::CapacityReduced,
-                    &mut self.source_removal_metrics,
-                    reporter,
-                );
-            }
-        }
-        while self.legacy_parsers.len() > max {
-            if let Some((source, (parser, _))) = self.legacy_parsers.pop_lru() {
-                drop(parser);
-                report_source_removal(
-                    AutoSourceKey::Legacy(source),
-                    SourceRemovalCause::CapacityReduced,
-                    &mut self.source_removal_metrics,
-                    reporter,
-                );
-            }
+        while self.source_count() > max {
+            let Some((source, parser)) = self.pop_global_lru() else {
+                break;
+            };
+            drop(parser);
+            report_source_removal(
+                source,
+                SourceRemovalCause::CapacityReduced,
+                &mut self.source_removal_metrics,
+                reporter,
+            );
         }
         // Keep every physical cache at the global limit. The cross-cache
         // pressure path below enforces the total source count.
@@ -1167,10 +1146,7 @@ impl AutoScopedParser {
 
     /// Evict the globally least-recently-used entry across all three caches.
     /// Uses O(1) peek at the LRU entry of each cache, then pops from the oldest.
-    fn evict_global_lru<F>(&mut self, reporter: &mut F)
-    where
-        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
-    {
+    fn pop_global_lru(&mut self) -> Option<(AutoSourceKey, NetflowParser)> {
         let ipfix_ts = self.ipfix_parsers.peek_lru().map(|(_, (_, ts))| *ts);
         let v9_ts = self.v9_parsers.peek_lru().map(|(_, (_, ts))| *ts);
         let legacy_ts = self.legacy_parsers.peek_lru().map(|(_, (_, ts))| *ts);
@@ -1199,47 +1175,46 @@ impl AutoScopedParser {
             })
             .map(|(kind, _, _)| *kind);
 
+        match oldest {
+            Some(MapKind::Ipfix) => self
+                .ipfix_parsers
+                .pop_lru()
+                .map(|(source, (parser, _))| (AutoSourceKey::Ipfix(source), parser)),
+            Some(MapKind::V9) => self
+                .v9_parsers
+                .pop_lru()
+                .map(|(source, (parser, _))| (AutoSourceKey::V9(source), parser)),
+            Some(MapKind::Legacy) => self
+                .legacy_parsers
+                .pop_lru()
+                .map(|(source, (parser, _))| (AutoSourceKey::Legacy(source), parser)),
+            None => None,
+        }
+    }
+
+    fn evict_global_lru<F>(&mut self, reporter: &mut F)
+    where
+        F: FnMut(&SourceRemoval<AutoSourceKey>) -> Result<(), SourceRemovalReporterError>,
+    {
+        let Some((source, mut parser)) = self.pop_global_lru() else {
+            return;
+        };
+
         // Preserve the existing pressure-eviction behavior: clear the evicted
         // AutoScoped child's protocol templates before dropping it. Other
         // removal paths deliberately retain their pre-existing behavior.
-        match oldest {
-            Some(MapKind::Ipfix) => {
-                if let Some((source, (mut parser, _))) = self.ipfix_parsers.pop_lru() {
-                    parser.clear_ipfix_templates();
-                    drop(parser);
-                    report_source_removal(
-                        AutoSourceKey::Ipfix(source),
-                        SourceRemovalCause::CapacityPressure,
-                        &mut self.source_removal_metrics,
-                        reporter,
-                    );
-                }
-            }
-            Some(MapKind::V9) => {
-                if let Some((source, (mut parser, _))) = self.v9_parsers.pop_lru() {
-                    parser.clear_v9_templates();
-                    drop(parser);
-                    report_source_removal(
-                        AutoSourceKey::V9(source),
-                        SourceRemovalCause::CapacityPressure,
-                        &mut self.source_removal_metrics,
-                        reporter,
-                    );
-                }
-            }
-            Some(MapKind::Legacy) => {
-                if let Some((source, (parser, _))) = self.legacy_parsers.pop_lru() {
-                    drop(parser);
-                    report_source_removal(
-                        AutoSourceKey::Legacy(source),
-                        SourceRemovalCause::CapacityPressure,
-                        &mut self.source_removal_metrics,
-                        reporter,
-                    );
-                }
-            }
-            None => {}
+        match source {
+            AutoSourceKey::Ipfix(_) => parser.clear_ipfix_templates(),
+            AutoSourceKey::V9(_) => parser.clear_v9_templates(),
+            AutoSourceKey::Legacy(_) => {}
         }
+        drop(parser);
+        report_source_removal(
+            source,
+            SourceRemovalCause::CapacityPressure,
+            &mut self.source_removal_metrics,
+            reporter,
+        );
     }
 
     /// Create a new parser instance using the configured builder or default

--- a/src/scoped_parser/source_removal.rs
+++ b/src/scoped_parser/source_removal.rs
@@ -1,0 +1,82 @@
+/// Why a scoped parser implicitly removed a source.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceRemovalCause {
+    /// A new source displaced the least-recently-used source at capacity.
+    CapacityPressure,
+    /// The source exceeded the caller's idle threshold.
+    Idle,
+    /// Reducing the configured source capacity displaced the source.
+    CapacityReduced,
+}
+
+/// Exact information about one implicitly removed scoped parser.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRemoval<K> {
+    /// Exact source key owned by the removed child parser.
+    pub source: K,
+    /// Why the parser removed this source.
+    pub cause: SourceRemovalCause,
+}
+
+/// Error returned by a source-removal reporter.
+pub type SourceRemovalReporterError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Aggregate source-removal metrics retained by a scoped parser.
+#[non_exhaustive]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SourceRemovalMetrics {
+    /// Sources removed because a new source arrived at capacity.
+    pub capacity_pressure: u64,
+    /// Sources removed by idle pruning.
+    pub idle: u64,
+    /// Sources removed because the configured capacity was reduced.
+    pub capacity_reduced: u64,
+    /// Reporter calls that returned an error or panicked.
+    pub reporter_failures: u64,
+}
+
+impl SourceRemovalMetrics {
+    fn record_removal(&mut self, cause: SourceRemovalCause) {
+        match cause {
+            SourceRemovalCause::CapacityPressure => {
+                self.capacity_pressure = self.capacity_pressure.saturating_add(1);
+            }
+            SourceRemovalCause::Idle => {
+                self.idle = self.idle.saturating_add(1);
+            }
+            SourceRemovalCause::CapacityReduced => {
+                self.capacity_reduced = self.capacity_reduced.saturating_add(1);
+            }
+        }
+    }
+
+    fn record_reporter_failure(&mut self) {
+        self.reporter_failures = self.reporter_failures.saturating_add(1);
+    }
+}
+
+pub(super) fn ignore_source_removal<K>(
+    _removal: &SourceRemoval<K>,
+) -> Result<(), SourceRemovalReporterError> {
+    Ok(())
+}
+
+pub(super) fn report_source_removal<K, F>(
+    source: K,
+    cause: SourceRemovalCause,
+    metrics: &mut SourceRemovalMetrics,
+    reporter: &mut F,
+) where
+    F: FnMut(&SourceRemoval<K>) -> Result<(), SourceRemovalReporterError>,
+{
+    metrics.record_removal(cause);
+    let removal = SourceRemoval { source, cause };
+    let delivered =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| reporter(&removal).is_ok()))
+            .unwrap_or(false);
+    if !delivered {
+        metrics.record_reporter_failure();
+    }
+}

--- a/tests/scoped_source_removal_reporting.rs
+++ b/tests/scoped_source_removal_reporting.rs
@@ -1,0 +1,598 @@
+use netflow_parser::{
+    AutoScopedParser, AutoSourceKey, InMemoryTemplateStore, NetflowPacket, NetflowParser,
+    RouterScopedParser, SourceRemovalCause, V9SourceKey,
+};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+const V5_PACKET: [u8; 72] = [
+    0, 5, 0, 1, 3, 0, 4, 0, 5, 0, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
+    6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5,
+    6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7,
+];
+
+fn v9_template_packet(source_id: u32, template_id: u16) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&source_id.to_be_bytes());
+    packet.extend_from_slice(&0u16.to_be_bytes());
+    packet.extend_from_slice(&12u16.to_be_bytes());
+    packet.extend_from_slice(&template_id.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+    packet
+}
+
+fn v9_data_packet(source_id: u32, template_id: u16, payload: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&source_id.to_be_bytes());
+    packet.extend_from_slice(&template_id.to_be_bytes());
+    packet.extend_from_slice(&((4 + payload.len()) as u16).to_be_bytes());
+    packet.extend_from_slice(payload);
+    packet
+}
+
+fn has_decoded_v9_data(packets: &[NetflowPacket]) -> bool {
+    packets.iter().any(|packet| match packet {
+        NetflowPacket::V9(v9) => v9.flowsets.iter().any(|flowset| {
+            matches!(
+                flowset.body,
+                netflow_parser::variable_versions::v9::FlowSetBody::Data(_)
+            )
+        }),
+        _ => false,
+    })
+}
+
+fn empty_ipfix_packet(observation_domain_id: u32) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&10u16.to_be_bytes());
+    packet.extend_from_slice(&16u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&observation_domain_id.to_be_bytes());
+    packet
+}
+
+#[test]
+fn router_parse_reports_exact_pressure_removal() {
+    let mut parser = RouterScopedParser::<String>::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let _ = parser.parse_from_source("router-a".into(), &V5_PACKET);
+
+    let mut removals = Vec::new();
+    let result =
+        parser.parse_from_source_with_reporter("router-b".into(), &V5_PACKET, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        });
+
+    assert!(result.error.is_none());
+    assert_eq!(removals.len(), 1);
+    assert_eq!(removals[0].source, "router-a");
+    assert_eq!(removals[0].cause, SourceRemovalCause::CapacityPressure);
+    assert!(parser.get_parser(&"router-a".to_string()).is_none());
+    assert!(parser.get_parser(&"router-b".to_string()).is_some());
+    let metrics = parser.source_removal_metrics();
+    assert_eq!(metrics.capacity_pressure, 1);
+    assert_eq!(metrics.idle, 0);
+    assert_eq!(metrics.capacity_reduced, 0);
+}
+
+#[test]
+fn auto_iterator_reports_exact_v9_pressure_removal() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let source_a: SocketAddr = "192.0.2.1:2055".parse().unwrap();
+    let source_b: SocketAddr = "192.0.2.2:2055".parse().unwrap();
+    let packet_a = v9_template_packet(11, 256);
+    let packet_b = v9_template_packet(22, 256);
+    let _ = parser.parse_from_source(source_a, &packet_a);
+
+    let mut removals = Vec::new();
+    let iterator = parser
+        .iter_packets_from_source_with_reporter(source_b, &packet_b, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("iterator");
+    let results: Vec<_> = iterator.collect();
+    assert!(results.iter().all(Result::is_ok));
+
+    assert_eq!(removals.len(), 1);
+    assert_eq!(
+        removals[0].source,
+        AutoSourceKey::V9(V9SourceKey {
+            addr: source_a,
+            source_id: 11,
+        })
+    );
+    assert_eq!(removals[0].cause, SourceRemovalCause::CapacityPressure);
+    assert_eq!(parser.source_count(), 1);
+}
+
+#[test]
+fn router_iterator_reports_exact_pressure_removal() {
+    let mut parser = RouterScopedParser::<String>::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let _ = parser.parse_from_source("a".into(), &V5_PACKET);
+
+    let mut removals = Vec::new();
+    let iterator = parser
+        .iter_packets_from_source_with_reporter("b".into(), &V5_PACKET, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("iterator");
+    assert_eq!(iterator.count(), 1);
+
+    assert_eq!(removals.len(), 1);
+    assert_eq!(removals[0].source, "a");
+    assert_eq!(removals[0].cause, SourceRemovalCause::CapacityPressure);
+}
+
+#[test]
+fn router_idle_prune_reports_every_removed_key() {
+    let mut parser = RouterScopedParser::<String>::new();
+    for source in ["a", "b", "c"] {
+        let _ = parser.parse_from_source(source.to_string(), &V5_PACKET);
+    }
+
+    let mut removals = Vec::new();
+    let count = parser.prune_idle_sources_with_reporter(Duration::ZERO, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert_eq!(count, 3);
+    assert_eq!(parser.source_count(), 0);
+    assert_eq!(removals.len(), 3);
+    assert!(
+        removals
+            .iter()
+            .all(|removal| removal.cause == SourceRemovalCause::Idle)
+    );
+    let mut sources: Vec<_> = removals.into_iter().map(|removal| removal.source).collect();
+    sources.sort();
+    assert_eq!(sources, ["a", "b", "c"]);
+    assert_eq!(parser.source_removal_metrics().idle, 3);
+}
+
+#[test]
+fn auto_idle_prune_reports_all_source_key_variants() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(3)
+        .expect("valid limit");
+    let legacy_addr: SocketAddr = "192.0.2.10:2055".parse().unwrap();
+    let v9_addr: SocketAddr = "192.0.2.11:2055".parse().unwrap();
+    let ipfix_addr: SocketAddr = "192.0.2.12:2055".parse().unwrap();
+    let _ = parser.parse_from_source(legacy_addr, &V5_PACKET);
+    let _ = parser.parse_from_source(v9_addr, &v9_template_packet(7, 256));
+    let _ = parser.parse_from_source(ipfix_addr, &empty_ipfix_packet(9));
+
+    let mut removals = Vec::new();
+    let count = parser.prune_idle_sources_with_reporter(Duration::ZERO, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert_eq!(count, 3);
+    assert!(removals.iter().any(|removal| {
+        removal.source == AutoSourceKey::Legacy(legacy_addr)
+            && removal.cause == SourceRemovalCause::Idle
+    }));
+    assert!(removals.iter().any(|removal| {
+        removal.source
+            == AutoSourceKey::V9(V9SourceKey {
+                addr: v9_addr,
+                source_id: 7,
+            })
+    }));
+    assert!(removals.iter().any(|removal| {
+        removal.source
+            == AutoSourceKey::Ipfix(netflow_parser::IpfixSourceKey {
+                addr: ipfix_addr,
+                observation_domain_id: 9,
+            })
+    }));
+}
+
+#[test]
+fn router_resize_reports_each_capacity_reduction() {
+    let mut parser = RouterScopedParser::<String>::new()
+        .with_max_sources(4)
+        .expect("valid limit");
+    for source in ["a", "b", "c", "d"] {
+        let _ = parser.parse_from_source(source.to_string(), &V5_PACKET);
+    }
+
+    let mut removals = Vec::new();
+    parser = parser
+        .with_max_sources_and_reporter(2, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("valid resize");
+
+    assert_eq!(parser.source_count(), 2);
+    assert_eq!(
+        removals
+            .iter()
+            .map(|removal| removal.source.as_str())
+            .collect::<Vec<_>>(),
+        ["a", "b"]
+    );
+    assert!(
+        removals
+            .iter()
+            .all(|removal| removal.cause == SourceRemovalCause::CapacityReduced)
+    );
+    assert_eq!(parser.source_removal_metrics().capacity_reduced, 2);
+}
+
+#[test]
+fn auto_resize_reports_every_existing_per_cache_removal() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(3)
+        .expect("valid limit");
+    let sources: [SocketAddr; 3] = [
+        "198.51.100.1:2055".parse().unwrap(),
+        "198.51.100.2:2055".parse().unwrap(),
+        "198.51.100.3:2055".parse().unwrap(),
+    ];
+    for (source_id, source) in sources.into_iter().enumerate() {
+        let _ = parser.parse_from_source(source, &v9_template_packet(source_id as u32, 256));
+    }
+
+    let mut removals = Vec::new();
+    parser = parser
+        .with_max_sources_and_reporter(1, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("valid resize");
+
+    assert_eq!(parser.source_count(), 1);
+    assert_eq!(removals.len(), 2);
+    assert!(
+        removals
+            .iter()
+            .all(|removal| removal.cause == SourceRemovalCause::CapacityReduced)
+    );
+    assert_eq!(parser.source_removal_metrics().capacity_reduced, 2);
+}
+
+#[test]
+fn reporter_errors_and_panics_do_not_interrupt_pressure_replacement() {
+    let mut parser = RouterScopedParser::<String>::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let _ = parser.parse_from_source("a".into(), &V5_PACKET);
+
+    let result = parser.parse_from_source_with_reporter("b".into(), &V5_PACKET, &mut |_| {
+        Err(std::io::Error::other("report failed").into())
+    });
+    assert!(result.error.is_none());
+    assert!(parser.get_parser(&"b".to_string()).is_some());
+    assert_eq!(parser.source_removal_metrics().reporter_failures, 1);
+
+    let result = parser.parse_from_source_with_reporter("c".into(), &V5_PACKET, &mut |_| {
+        panic!("reporter panic")
+    });
+    assert!(result.error.is_none());
+    assert!(parser.get_parser(&"c".to_string()).is_some());
+    assert_eq!(parser.source_removal_metrics().reporter_failures, 2);
+}
+
+#[test]
+fn unscopable_auto_source_never_evicts_or_reports() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let valid_source: SocketAddr = "203.0.113.1:2055".parse().unwrap();
+    let malformed_source: SocketAddr = "203.0.113.2:2055".parse().unwrap();
+    let _ = parser.parse_from_source(valid_source, &V5_PACKET);
+
+    let mut removals = Vec::new();
+    let result =
+        parser.parse_from_source_with_reporter(malformed_source, &[0, 9], &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        });
+
+    assert!(result.error.is_some());
+    assert!(removals.is_empty());
+    assert_eq!(parser.source_count(), 1);
+    assert_eq!(parser.source_removal_metrics().capacity_pressure, 0);
+}
+
+#[test]
+fn existing_source_does_not_report_or_increment_removal_metrics() {
+    let mut parser = RouterScopedParser::<String>::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let source = "a".to_string();
+    let _ = parser.parse_from_source(source.clone(), &V5_PACKET);
+
+    let mut removals = Vec::new();
+    let result = parser.parse_from_source_with_reporter(source, &V5_PACKET, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert!(result.error.is_none());
+    assert!(removals.is_empty());
+    assert_eq!(parser.source_removal_metrics(), Default::default());
+}
+
+#[test]
+fn auto_pressure_reports_global_lru_across_protocol_caches() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(2)
+        .expect("valid limit");
+    let legacy_addr: SocketAddr = "203.0.113.10:2055".parse().unwrap();
+    let v9_addr: SocketAddr = "203.0.113.11:2055".parse().unwrap();
+    let ipfix_addr: SocketAddr = "203.0.113.12:2055".parse().unwrap();
+    let _ = parser.parse_from_source(legacy_addr, &V5_PACKET);
+    let _ = parser.parse_from_source(v9_addr, &v9_template_packet(17, 256));
+    let _ = parser.parse_from_source(legacy_addr, &V5_PACKET);
+
+    let mut removals = Vec::new();
+    let _ = parser.parse_from_source_with_reporter(
+        ipfix_addr,
+        &empty_ipfix_packet(19),
+        &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        },
+    );
+
+    assert_eq!(removals.len(), 1);
+    assert_eq!(
+        removals[0].source,
+        AutoSourceKey::V9(V9SourceKey {
+            addr: v9_addr,
+            source_id: 17,
+        })
+    );
+    assert_eq!(parser.source_count(), 2);
+}
+
+#[test]
+fn auto_pressure_reports_exact_ipfix_and_legacy_sources() {
+    let ipfix_addr: SocketAddr = "203.0.113.20:2055".parse().unwrap();
+    let legacy_addr: SocketAddr = "203.0.113.21:2055".parse().unwrap();
+
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let _ = parser.parse_from_source(ipfix_addr, &empty_ipfix_packet(23));
+    let mut removals = Vec::new();
+    let _ = parser.parse_from_source_with_reporter(legacy_addr, &V5_PACKET, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+    assert_eq!(
+        removals[0].source,
+        AutoSourceKey::Ipfix(netflow_parser::IpfixSourceKey {
+            addr: ipfix_addr,
+            observation_domain_id: 23,
+        })
+    );
+    assert_eq!(removals[0].cause, SourceRemovalCause::CapacityPressure);
+
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let _ = parser.parse_from_source(legacy_addr, &V5_PACKET);
+    let mut removals = Vec::new();
+    let _ = parser.parse_from_source_with_reporter(
+        ipfix_addr,
+        &empty_ipfix_packet(23),
+        &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        },
+    );
+    assert_eq!(removals[0].source, AutoSourceKey::Legacy(legacy_addr));
+    assert_eq!(removals[0].cause, SourceRemovalCause::CapacityPressure);
+}
+
+#[test]
+fn auto_existing_source_does_not_report_or_increment_removal_metrics() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(1)
+        .expect("valid limit");
+    let source: SocketAddr = "203.0.113.30:2055".parse().unwrap();
+    let packet = v9_template_packet(31, 256);
+    let _ = parser.parse_from_source(source, &packet);
+
+    let mut removals = Vec::new();
+    let result = parser.parse_from_source_with_reporter(source, &packet, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert!(result.error.is_none());
+    assert!(removals.is_empty());
+    assert_eq!(parser.source_removal_metrics(), Default::default());
+}
+
+#[test]
+fn auto_pressure_reporting_preserves_existing_store_cleanup() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser = AutoScopedParser::try_with_builder(builder)
+        .expect("valid builder")
+        .with_max_sources(1)
+        .expect("valid limit");
+    let source_a: SocketAddr = "10.0.0.1:2055".parse().unwrap();
+    let source_b: SocketAddr = "10.0.0.2:2055".parse().unwrap();
+    let _ = parser.parse_from_source(source_a, &v9_template_packet(1, 256));
+    assert_eq!(store.len(), 1);
+
+    let mut removals = Vec::new();
+    let _ = parser.parse_from_source_with_reporter(
+        source_b,
+        &v9_template_packet(2, 256),
+        &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        },
+    );
+
+    assert_eq!(removals.len(), 1);
+    assert_eq!(store.len(), 1, "pressure cleanup must remain unchanged");
+}
+
+#[test]
+fn auto_idle_reporting_preserves_existing_store_entries() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser = AutoScopedParser::try_with_builder(builder).expect("valid builder");
+    let source: SocketAddr = "10.0.0.3:2055".parse().unwrap();
+    let _ = parser.parse_from_source(source, &v9_template_packet(3, 256));
+
+    let mut removals = Vec::new();
+    let count = parser.prune_idle_sources_with_reporter(Duration::ZERO, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert_eq!(count, 1);
+    assert_eq!(removals.len(), 1);
+    assert_eq!(store.len(), 1, "idle removal must not add store cleanup");
+}
+
+#[test]
+fn auto_resize_reporting_preserves_existing_store_entries() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser = AutoScopedParser::try_with_builder(builder)
+        .expect("valid builder")
+        .with_max_sources(3)
+        .expect("valid limit");
+    for source_id in 1..=3 {
+        let source: SocketAddr = format!("10.0.1.{source_id}:2055").parse().unwrap();
+        let _ = parser.parse_from_source(source, &v9_template_packet(source_id, 256));
+    }
+    assert_eq!(store.len(), 3);
+
+    let mut removals = Vec::new();
+    parser = parser
+        .with_max_sources_and_reporter(1, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("valid resize");
+
+    assert_eq!(parser.source_count(), 1);
+    assert_eq!(removals.len(), 2);
+    assert_eq!(store.len(), 3, "resize must not add store cleanup");
+}
+
+#[test]
+fn router_pressure_reporting_preserves_shared_store_entry() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser = RouterScopedParser::<String>::try_with_builder(builder)
+        .expect("valid builder")
+        .with_max_sources(2)
+        .expect("valid limit");
+    let _ = parser.parse_from_source("a".into(), &v9_template_packet(1, 256));
+    let _ = parser.parse_from_source("b".into(), &v9_template_packet(2, 256));
+
+    let mut removals = Vec::new();
+    let _ = parser.parse_from_source_with_reporter("c".into(), &V5_PACKET, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+    assert_eq!(removals[0].source, "a");
+    assert_eq!(store.len(), 1, "reporting must not add Router cleanup");
+
+    let mut replica = NetflowParser::builder()
+        .with_template_store(store)
+        .build()
+        .expect("valid replica");
+    let result = replica.parse_bytes(&v9_data_packet(2, 256, &[0, 0, 0, 42]));
+    assert!(has_decoded_v9_data(&result.packets));
+}
+
+#[test]
+fn router_idle_reporting_preserves_shared_store_entry() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser =
+        RouterScopedParser::<String>::try_with_builder(builder).expect("valid builder");
+    let _ = parser.parse_from_source("a".into(), &v9_template_packet(1, 256));
+    let _ = parser.parse_from_source("b".into(), &v9_template_packet(2, 256));
+
+    let mut removals = Vec::new();
+    let count = parser.prune_idle_sources_with_reporter(Duration::ZERO, &mut |removal| {
+        removals.push(removal.clone());
+        Ok(())
+    });
+
+    assert_eq!(count, 2);
+    assert_eq!(removals.len(), 2);
+    assert_eq!(store.len(), 1, "idle reporting must not add Router cleanup");
+}
+
+#[test]
+fn router_resize_reporting_preserves_shared_store_entry() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser = RouterScopedParser::<String>::try_with_builder(builder)
+        .expect("valid builder")
+        .with_max_sources(3)
+        .expect("valid limit");
+    for source in ["a", "b", "c"] {
+        let _ = parser.parse_from_source(source.into(), &v9_template_packet(1, 256));
+    }
+
+    let mut removals = Vec::new();
+    parser = parser
+        .with_max_sources_and_reporter(1, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("valid resize");
+
+    assert_eq!(parser.source_count(), 1);
+    assert_eq!(removals.len(), 2);
+    assert_eq!(
+        store.len(),
+        1,
+        "resize reporting must not add Router cleanup"
+    );
+}
+
+#[test]
+fn explicit_removal_transfers_parser_without_reporting() {
+    let store = Arc::new(InMemoryTemplateStore::new());
+    let builder = NetflowParser::builder().with_template_store(store.clone());
+    let mut parser =
+        RouterScopedParser::<String>::try_with_builder(builder).expect("valid builder");
+    let source = "a".to_string();
+    let _ = parser.parse_from_source(source.clone(), &v9_template_packet(1, 256));
+
+    let removed = parser.remove_source(&source);
+
+    assert!(removed.is_some());
+    assert_eq!(store.len(), 1);
+    assert_eq!(parser.source_removal_metrics(), Default::default());
+}

--- a/tests/scoped_source_removal_reporting.rs
+++ b/tests/scoped_source_removal_reporting.rs
@@ -277,6 +277,46 @@ fn auto_resize_reports_every_existing_per_cache_removal() {
 }
 
 #[test]
+fn auto_resize_enforces_global_limit_across_protocol_caches() {
+    let mut parser = AutoScopedParser::new()
+        .with_max_sources(6)
+        .expect("valid limit");
+
+    for source in ["198.51.100.10:2055", "198.51.100.11:2055"] {
+        let source: SocketAddr = source.parse().unwrap();
+        let _ = parser.parse_from_source(source, &V5_PACKET);
+    }
+    for (source, source_id) in [("198.51.100.20:2055", 20), ("198.51.100.21:2055", 21)] {
+        let source: SocketAddr = source.parse().unwrap();
+        let _ = parser.parse_from_source(source, &v9_template_packet(source_id, 256));
+    }
+    for (source, observation_domain_id) in
+        [("198.51.100.30:2055", 30), ("198.51.100.31:2055", 31)]
+    {
+        let source: SocketAddr = source.parse().unwrap();
+        let _ = parser.parse_from_source(source, &empty_ipfix_packet(observation_domain_id));
+    }
+    assert_eq!(parser.source_count(), 6);
+
+    let mut removals = Vec::new();
+    parser = parser
+        .with_max_sources_and_reporter(2, &mut |removal| {
+            removals.push(removal.clone());
+            Ok(())
+        })
+        .expect("valid resize");
+
+    assert_eq!(parser.source_count(), 2);
+    assert_eq!(removals.len(), 4);
+    assert!(
+        removals
+            .iter()
+            .all(|removal| removal.cause == SourceRemovalCause::CapacityReduced)
+    );
+    assert_eq!(parser.source_removal_metrics().capacity_reduced, 4);
+}
+
+#[test]
 fn reporter_errors_and_panics_do_not_interrupt_pressure_replacement() {
     let mut parser = RouterScopedParser::<String>::new()
         .with_max_sources(1)


### PR DESCRIPTION
## Summary

Add opt-in, synchronous reports for every implicit source removal performed by `AutoScopedParser` and `RouterScopedParser`.

Reports identify:

- the exact removed source;
- whether it was removed by capacity pressure, idle pruning, or a capacity reduction.

## Problem

Scoped parsers bound memory by automatically removing source-specific child parsers. Applications can keep state associated with those sources, but the existing APIs discard the removed key. This leaves applications unable to remove their corresponding state accurately.

## Design

- Add `*_with_reporter` companions for parsing, iterator parsing, idle pruning, and capacity changes.
- Keep every existing method as a source-compatible wrapper that discards reports.
- Isolate reporter errors and unwind panics so a reporting failure cannot interrupt the completed parser-state transition.
- Retain aggregate removal and reporter-failure counters after child parsers are gone.
- Keep explicit `remove_*` methods unchanged as caller-owned parser transfers; they do not emit implicit-removal reports.
- Preserve every existing `TemplateStore` operation exactly. This change neither adds nor removes persistence cleanup.

## Compatibility

Existing callers require no changes. Reporting is opt-in through the companion methods.

## Validation

- 20 focused integration tests cover exact source/cause reporting, both parser APIs, all source-key variants, all three removal causes, error/panic isolation, malformed and existing-source no-op paths, global LRU selection, explicit removal, and every existing `TemplateStore` behavior.
- Full `scripts/check-all.sh` suite passes.
- Default and no-default-feature tests pass.
- Rust 1.88 compatibility tests pass.

## Performance

Paired, CPU-pinned, 11-trial base/candidate measurements show:

- normal parsing: worst candidate/base throughput ratio 98.8%;
- forced removal on every operation: worst compatibility-wrapper/base ratio 97.3%;
- explicit reporting on forced removals: effectively equal to baseline;
- allocation counts and allocated bytes unchanged in every measured scenario.
