### PR TITLE
test: expose malformed IPFIX message state leak

### DIFF
--- a/tests/ipfix_malformed_message.rs
+++ b/tests/ipfix_malformed_message.rs
@@ -1,0 +1,36 @@
+use netflow_parser::NetflowParser;
+
+fn append_set(message: &mut Vec<u8>, id: u16, body: &[u8]) {
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+}
+
+#[test]
+fn malformed_message_does_not_commit_an_earlier_template() {
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&0u16.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+    append_set(&mut message, 2, &template);
+
+    message.extend_from_slice(&2u16.to_be_bytes());
+    message.extend_from_slice(&3u16.to_be_bytes());
+    let length = u16::try_from(message.len()).unwrap();
+    message[2..4].copy_from_slice(&length.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    let result = parser.parse_bytes(&message);
+
+    assert!(result.error.is_some());
+    assert!(result.packets.is_empty());
+    assert!(!parser.has_ipfix_template(256));
+}


### PR DESCRIPTION
## Intentionally failing test-only draft

This draft adds one synthetic regression test and intentionally leaves CI red. It does not propose or implement a parser fix; the maintainer owns the remediation.

### Baseline

- `v1.0.6` and current `main`: `798b3d8b5acafc9257a2ec983824627c81e13f62`
- The unmodified baseline suite passes.

### Reproducer

The message contains a valid Template Set followed by a Set whose declared length is 3, shorter than the four-octet Set header.

Observed on the baseline:

- parsing reports no error;
- the earlier template remains in the parser cache.

Expected:

- the malformed message is rejected as a whole;
- it produces no packet and commits no template state.

### Contract and impact

[RFC 7011 section 9.1](https://www.rfc-editor.org/rfc/rfc7011.html#section-9.1) says a malformed IPFIX Message must be discarded. Committing state from its valid prefix can poison the template cache, so later Data Sets may be decoded using a template learned from a message that should never have been accepted.

### Exact validation

```text
cargo test --test ipfix_malformed_message malformed_message_does_not_commit_an_earlier_template -- --exact
```

The test compiles successfully and fails on the unchanged baseline at `assert!(result.error.is_some())`.
### Why this remains test-only

A Set-length preflight would fix only this literal packet. A later correctly framed Set with malformed Template content can still mutate the same caches before the message is known to be invalid. Complete message-discard semantics require transaction-wide staging or rollback across template caches, pending flows, metrics/events, and secondary-store effects (or a stateless validation pass).

That is an architectural transaction boundary, not a surgical correction, so this draft intentionally remains the standalone failing evidence for maintainer design and implementation.