### PR TITLE
fix: apply IPFIX template withdrawals in wire order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1978,13 +1978,15 @@ impl NetflowParser {
                 for fs in &ipfix.flowsets {
                     match &fs.body {
                         variable_versions::ipfix::FlowSetBody::Template(t) => {
-                            self.template_hooks.trigger(&TemplateEvent::Learned {
-                                template_id: Some(t.template_id),
-                                protocol: TemplateProtocol::Ipfix,
-                            });
+                            if t.field_count > 0 {
+                                self.template_hooks.trigger(&TemplateEvent::Learned {
+                                    template_id: Some(t.template_id),
+                                    protocol: TemplateProtocol::Ipfix,
+                                });
+                            }
                         }
                         variable_versions::ipfix::FlowSetBody::Templates(ts) => {
-                            for t in ts {
+                            for t in ts.iter().filter(|t| t.field_count > 0) {
                                 self.template_hooks.trigger(&TemplateEvent::Learned {
                                     template_id: Some(t.template_id),
                                     protocol: TemplateProtocol::Ipfix,
@@ -2006,13 +2008,15 @@ impl NetflowParser {
                             }
                         }
                         variable_versions::ipfix::FlowSetBody::OptionsTemplate(t) => {
-                            self.template_hooks.trigger(&TemplateEvent::Learned {
-                                template_id: Some(t.template_id),
-                                protocol: TemplateProtocol::Ipfix,
-                            });
+                            if t.field_count > 0 {
+                                self.template_hooks.trigger(&TemplateEvent::Learned {
+                                    template_id: Some(t.template_id),
+                                    protocol: TemplateProtocol::Ipfix,
+                                });
+                            }
                         }
                         variable_versions::ipfix::FlowSetBody::OptionsTemplates(ts) => {
-                            for t in ts {
+                            for t in ts.iter().filter(|t| t.field_count > 0) {
                                 self.template_hooks.trigger(&TemplateEvent::Learned {
                                     template_id: Some(t.template_id),
                                     protocol: TemplateProtocol::Ipfix,

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -625,10 +625,12 @@ impl IPFixParser {
                     }
                 }
                 FlowSetBody::Template(t) => {
-                    learned_template_ids.push(t.template_id);
+                    if t.field_count > 0 {
+                        learned_template_ids.push(t.template_id);
+                    }
                 }
                 FlowSetBody::Templates(ts) => {
-                    for t in ts.iter() {
+                    for t in ts.iter().filter(|t| t.field_count > 0) {
                         learned_template_ids.push(t.template_id);
                     }
                 }
@@ -641,10 +643,12 @@ impl IPFixParser {
                     }
                 }
                 FlowSetBody::OptionsTemplate(t) => {
-                    learned_template_ids.push(t.template_id);
+                    if t.field_count > 0 {
+                        learned_template_ids.push(t.template_id);
+                    }
                 }
                 FlowSetBody::OptionsTemplates(ts) => {
-                    for t in ts.iter() {
+                    for t in ts.iter().filter(|t| t.field_count > 0) {
                         learned_template_ids.push(t.template_id);
                     }
                 }
@@ -1392,6 +1396,8 @@ impl IPFixParser {
     }
 }
 
+type WithdrawTemplate = (u16, fn(&mut IPFixParser, u16));
+
 impl FlowSetBody {
     #[allow(clippy::too_many_arguments)]
     fn parse_templates<'a, T, F>(
@@ -1402,7 +1408,7 @@ impl FlowSetBody {
         multi_variant: fn(Vec<T>) -> FlowSetBody,
         validate: fn(&T, &IPFixParser) -> bool,
         add_templates: fn(&mut IPFixParser, &[T]),
-        withdraw_template: Option<fn(&mut IPFixParser, u16)>,
+        withdraw_template: Option<WithdrawTemplate>,
     ) -> IResult<&'a [u8], FlowSetBody>
     where
         T: Clone + HasTemplateId,
@@ -1410,52 +1416,35 @@ impl FlowSetBody {
     {
         let (i, templates) = many0(complete(parse_fn))(i)?;
 
-        // Handle template withdrawals (RFC 7011 Section 8.1):
-        // Templates with field_count=0 signal withdrawal from the cache.
-        // Skip withdrawal for IDs that also have a new definition in the
-        // same flowset — the new definition will simply replace the old one
-        // without needlessly draining pending flows.
-        let mut had_withdrawals = false;
-        if let Some(withdraw_fn) = withdraw_template {
-            for t in &templates {
-                if t.field_count() == 0 {
-                    let id = t.template_id();
-                    // "Withdraw all" IDs (2 for data, 3 for options) always
-                    // take effect regardless of other templates in the batch.
-                    let has_redefinition = id != DATA_TEMPLATE_IPFIX_ID
-                        && id != OPTIONS_TEMPLATE_IPFIX_ID
-                        && templates
-                            .iter()
-                            .any(|other| other.template_id() == id && other.field_count() > 0);
-                    if !has_redefinition {
-                        withdraw_fn(parser, id);
-                    }
-                    had_withdrawals = true;
+        // Definitions and withdrawals take effect in their wire order. Keep
+        // withdrawals in the parsed representation so re-export can preserve
+        // the original Template Set.
+        let mut accepted_templates = Vec::with_capacity(templates.len());
+        for template in templates {
+            if template.field_count() == 0 {
+                // Reserved IDs can be zero-valued Set padding, not withdrawals.
+                if let Some((withdraw_all_id, withdraw_fn)) = withdraw_template
+                    && (template.template_id() == withdraw_all_id
+                        || template.template_id() >= 256)
+                {
+                    withdraw_fn(parser, template.template_id());
+                    accepted_templates.push(template);
                 }
+            } else if validate(&template, parser) {
+                add_templates(parser, std::slice::from_ref(&template));
+                accepted_templates.push(template);
             }
         }
 
-        // Filter to only valid templates (withdrawals will be filtered out
-        // since they have empty fields, failing the is_valid check)
-        let valid_templates: Vec<_> = templates
-            .into_iter()
-            .filter(|t| validate(t, parser))
-            .collect();
-        if valid_templates.is_empty() {
-            // If we processed withdrawals, return Empty instead of error
-            if had_withdrawals {
-                return Ok((i, FlowSetBody::Empty));
-            }
+        if accepted_templates.is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 i,
                 nom::error::ErrorKind::Verify,
             )));
         }
-        // Pass slice to add_templates to clone only what's needed
-        add_templates(parser, &valid_templates);
-        match valid_templates.len() {
+        match accepted_templates.len() {
             1 => {
-                if let Some(template) = valid_templates.into_iter().next() {
+                if let Some(template) = accepted_templates.into_iter().next() {
                     Ok((i, single_variant(template)))
                 } else {
                     Err(nom::Err::Error(nom::error::Error::new(
@@ -1464,7 +1453,7 @@ impl FlowSetBody {
                     )))
                 }
             }
-            _ => Ok((i, multi_variant(valid_templates))),
+            _ => Ok((i, multi_variant(accepted_templates))),
         }
     }
 
@@ -1482,7 +1471,9 @@ impl FlowSetBody {
                 FlowSetBody::Templates,
                 |t: &Template, p: &IPFixParser| t.is_valid(p),
                 |parser, templates| parser.add_ipfix_templates(templates),
-                Some(|parser: &mut IPFixParser, id| parser.withdraw_ipfix_template(id)),
+                Some((DATA_TEMPLATE_IPFIX_ID, |parser: &mut IPFixParser, id| {
+                    parser.withdraw_ipfix_template(id)
+                })),
             ),
             DATA_TEMPLATE_V9_ID => Self::parse_templates(
                 i,
@@ -1536,7 +1527,9 @@ impl FlowSetBody {
                 FlowSetBody::OptionsTemplates,
                 |t: &OptionsTemplate, p: &IPFixParser| t.is_valid(p),
                 |parser, templates| parser.add_ipfix_options_templates(templates),
-                Some(|parser: &mut IPFixParser, id| parser.withdraw_ipfix_options_template(id)),
+                Some((OPTIONS_TEMPLATE_IPFIX_ID, |parser: &mut IPFixParser, id| {
+                    parser.withdraw_ipfix_options_template(id);
+                })),
             ),
             // Parse Data
             _ => {

--- a/tests/ipfix_template_withdrawal_order.rs
+++ b/tests/ipfix_template_withdrawal_order.rs
@@ -1,0 +1,37 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn append_set(message: &mut Vec<u8>, id: u16, body: &[u8]) {
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+}
+
+#[test]
+fn template_withdrawal_takes_effect_in_wire_order() {
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&0u16.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+
+    let mut records = Vec::new();
+    records.extend_from_slice(&256u16.to_be_bytes());
+    records.extend_from_slice(&1u16.to_be_bytes());
+    records.extend_from_slice(&1u16.to_be_bytes());
+    records.extend_from_slice(&4u16.to_be_bytes());
+    records.extend_from_slice(&256u16.to_be_bytes());
+    records.extend_from_slice(&0u16.to_be_bytes());
+    append_set(&mut message, 2, &records);
+    append_set(&mut message, 256, &42u32.to_be_bytes());
+    let length = u16::try_from(message.len()).unwrap();
+    message[2..4].copy_from_slice(&length.to_be_bytes());
+
+    let result = NetflowParser::default().parse_bytes(&message);
+    assert!(result.error.is_none(), "{:#?}", result.error);
+    let NetflowPacket::IPFix(packet) = &result.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    assert!(matches!(packet.flowsets[1].body, FlowSetBody::NoTemplate(_)));
+}

--- a/tests/ipfix_template_withdrawal_order.rs
+++ b/tests/ipfix_template_withdrawal_order.rs
@@ -1,5 +1,7 @@
 use netflow_parser::variable_versions::ipfix::FlowSetBody;
-use netflow_parser::{NetflowPacket, NetflowParser};
+use netflow_parser::{NetflowPacket, NetflowParser, TemplateEvent};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn append_set(message: &mut Vec<u8>, id: u16, body: &[u8]) {
     message.extend_from_slice(&id.to_be_bytes());
@@ -28,10 +30,35 @@ fn template_withdrawal_takes_effect_in_wire_order() {
     let length = u16::try_from(message.len()).unwrap();
     message[2..4].copy_from_slice(&length.to_be_bytes());
 
-    let result = NetflowParser::default().parse_bytes(&message);
+    let learned_events = Arc::new(AtomicUsize::new(0));
+    let learned_events_for_hook = Arc::clone(&learned_events);
+    let mut parser = NetflowParser::builder()
+        .on_template_event(move |event| {
+            if matches!(event, TemplateEvent::Learned { .. }) {
+                learned_events_for_hook.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(())
+        })
+        .build()
+        .unwrap();
+    let result = parser.parse_bytes(&message);
     assert!(result.error.is_none(), "{:#?}", result.error);
     let NetflowPacket::IPFix(packet) = &result.packets[0] else {
         panic!("expected IPFIX packet");
     };
-    assert!(matches!(packet.flowsets[1].body, FlowSetBody::NoTemplate(_)));
+    let FlowSetBody::Templates(templates) = &packet.flowsets[0].body else {
+        panic!("expected both Template records");
+    };
+    assert_eq!(
+        templates
+            .iter()
+            .map(|template| template.field_count)
+            .collect::<Vec<_>>(),
+        [1, 0]
+    );
+    assert!(matches!(
+        packet.flowsets[1].body,
+        FlowSetBody::NoTemplate(_)
+    ));
+    assert_eq!(learned_events.load(Ordering::Relaxed), 1);
 }


### PR DESCRIPTION
## Draft regression test and surgical fix

This draft keeps the synthetic failing reproducer as commit 1 and adds the focused parser correction as commit 2.

### Baseline and reproducer

`v1.0.6` and the tested `main` baseline are both `798b3d8b5acafc9257a2ec983824627c81e13f62`; the unmodified suite passes.

One IPFIX Template Set defines Template ID 256 and then withdraws the same ID. A Data Set using ID 256 follows in the same message. On the baseline, the Data Set is incorrectly decoded with the withdrawn template.

### Root cause and fix

Template records were collected and validated as a batch: withdrawals were processed separately, while definitions were installed only afterward. That reversed the effective order of a definition followed by its withdrawal. Withdrawals were also removed from the parsed representation.

The parser now processes accepted Template records once in wire order, immediately applying definitions and RFC-valid withdrawals. Withdrawal records remain in the returned Template Set for faithful re-export. They are excluded from pending-flow replay IDs and `Learned` events because a withdrawal does not learn a template.

Only the matching withdraw-all ID (`2` for data Templates, `3` for Options Templates) or an individual Template ID of at least 256 is treated as a withdrawal. Reserved zero records can be Set padding and are not exposed as synthetic withdrawals, preserving existing tolerant parsing of a legacy malformed fixture.

### Contract and impact

[RFC 7011 section 8](https://www.rfc-editor.org/rfc/rfc7011.html#section-8) requires Template Withdrawals and definitions to take effect in the order in which they appear. Ignoring record order can decode bytes with a schema the exporter explicitly withdrew, producing incorrect field values rather than a visible template miss.

### Validation

```text
cargo test --test ipfix_template_withdrawal_order template_withdrawal_takes_effect_in_wire_order -- --exact
cargo test --test template_cache
cargo test --test template_store ipfix_template_withdrawal_evicts_from_store -- --exact
cargo test --test ipfix_template_id_ownership native_individual_withdrawal_removes_v9_style_owner -- --exact
cargo test --test ipfix_template_id_ownership native_withdraw_all_removes_both_encodings_of_the_template_class -- --exact
cargo test --lib tests::base_tests::parse_ipfix_with_v9_style_template -- --exact
cargo test --lib tests::malformed_packet_tests::test_ipfix_template_withdrawal -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All validations pass on commit 2. The PR remains a draft for maintainer review.