### PR TITLE
fix: accept all-scope IPFIX options templates

### DIFF
--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -387,10 +387,10 @@ pub(crate) trait CommonTemplate {
         if usize::from(self.get_field_count()) > max_field_count {
             return false;
         }
-        // Check scope field count if applicable (RFC 7011 Section 3.4.2.2:
-        // at least one scope field AND at least one non-scope field required)
+        // RFC 7011 Section 3.4.2.2 requires at least one scope field and
+        // permits every field in the Options Template to be a scope field.
         if let Some(scope_count) = self.get_scope_field_count()
-            && (scope_count == 0 || scope_count >= self.get_field_count())
+            && (scope_count == 0 || scope_count > self.get_field_count())
         {
             return false;
         }

--- a/tests/ipfix_all_scope_options.rs
+++ b/tests/ipfix_all_scope_options.rs
@@ -1,0 +1,40 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn options_template_can_contain_only_scope_fields() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&149u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    let learned = parser.parse_bytes(&message_with_set(3, &template));
+    assert!(learned.error.is_none(), "{:#?}", learned.error);
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &42u32.to_be_bytes()));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    assert!(matches!(
+        packet.flowsets[0].body,
+        FlowSetBody::OptionsData(_)
+    ));
+}


### PR DESCRIPTION
## Fix after the reproducer

This draft keeps the synthetic regression test as its first commit and adds a separate surgical fix commit.

### Root cause

The shared IPFIX template validator rejected an Options Template when `Scope Field Count == Field Count`, incorrectly requiring at least one non-scope field.

### Fix

The validator now rejects only:

- zero scope fields; or
- a scope count greater than the total field count.

The adjacent comment now matches RFC 7011.

### Contract and impact

[RFC 7011 section 3.4.2.2](https://www.rfc-editor.org/rfc/rfc7011.html#section-3.4.2.2) requires Scope Field Count to be nonzero and no greater than Field Count. Equality is valid. Exporters using all-scope templates now retain typed Options Data.

### Validation

```text
cargo test --test ipfix_all_scope_options options_template_can_contain_only_scope_fields -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
```

All checks pass on the PR branch.