### PR TITLE
fix: accept empty IPFIX variable-length values

### DIFF
--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -1985,13 +1985,6 @@ impl TemplateField {
                 let (i, length) = parse_u8(i)?;
                 if length == 255 {
                     let (i, full_length) = parse_u16_be(i)?;
-                    // RFC 7011 Section 7: length values of 0 are not permitted
-                    if full_length == 0 {
-                        return Err(nom::Err::Error(nom::error::Error::new(
-                            i,
-                            nom::error::ErrorKind::Verify,
-                        )));
-                    }
                     // Validate length doesn't exceed remaining buffer
                     if (full_length as usize) > i.len() {
                         return Err(nom::Err::Error(nom::error::Error::new(
@@ -2001,13 +1994,6 @@ impl TemplateField {
                     }
                     Ok((i, full_length))
                 } else {
-                    // RFC 7011 Section 7: length values of 0 are not permitted
-                    if length == 0 {
-                        return Err(nom::Err::Error(nom::error::Error::new(
-                            i,
-                            nom::error::ErrorKind::Verify,
-                        )));
-                    }
                     // Validate length doesn't exceed remaining buffer
                     if (length as usize) > i.len() {
                         return Err(nom::Err::Error(nom::error::Error::new(

--- a/src/variable_versions/ipfix/serializer.rs
+++ b/src/variable_versions/ipfix/serializer.rs
@@ -15,11 +15,6 @@ fn write_varlen_prefix(
     buf: &mut Vec<u8>,
     value_len: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if value_len == 0 {
-        return Err(
-            "IPFIX variable-length field cannot have zero length (RFC 7011 Section 7)".into(),
-        );
-    }
     if value_len < 255 {
         buf.push(value_len as u8);
     } else {

--- a/tests/ipfix_zero_length_varlen.rs
+++ b/tests/ipfix_zero_length_varlen.rs
@@ -28,7 +28,36 @@ fn one_octet_zero_length_value_is_a_data_record() {
     let learned = parser.parse_bytes(&message_with_set(2, &template));
     assert!(learned.error.is_none(), "{:#?}", learned.error);
 
-    let decoded = parser.parse_bytes(&message_with_set(256, &[0]));
+    let data_message = message_with_set(256, &[0]);
+    let decoded = parser.parse_bytes(&data_message);
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert_eq!(data.fields.len(), 1);
+    assert!(matches!(
+        &data.fields[0][0].1,
+        FieldValue::String(value) if value.raw.is_empty()
+    ));
+    assert!(packet.to_be_bytes().is_ok());
+}
+
+#[test]
+fn extended_zero_length_value_is_a_data_record() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&82u16.to_be_bytes());
+    template.extend_from_slice(&u16::MAX.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    let learned = parser.parse_bytes(&message_with_set(2, &template));
+    assert!(learned.error.is_none(), "{:#?}", learned.error);
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &[255, 0, 0]));
     assert!(decoded.error.is_none(), "{:#?}", decoded.error);
     let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
         panic!("expected IPFIX packet");

--- a/tests/ipfix_zero_length_varlen.rs
+++ b/tests/ipfix_zero_length_varlen.rs
@@ -1,0 +1,44 @@
+use netflow_parser::variable_versions::field_value::FieldValue;
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn one_octet_zero_length_value_is_a_data_record() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&82u16.to_be_bytes());
+    template.extend_from_slice(&u16::MAX.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    let learned = parser.parse_bytes(&message_with_set(2, &template));
+    assert!(learned.error.is_none(), "{:#?}", learned.error);
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &[0]));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert_eq!(data.fields.len(), 1);
+    assert!(matches!(
+        &data.fields[0][0].1,
+        FieldValue::String(value) if value.raw.is_empty()
+    ));
+}


### PR DESCRIPTION
## Fix after the reproducer

This draft keeps the synthetic regression test as its first commit and adds a separate surgical fix commit.

### Root cause

The IPFIX variable-length parser explicitly rejected both the one-octet and extended encodings when their decoded length was zero. The serializer independently rejected an empty variable-length value.

### Fix

The parser now accepts zero after consuming either valid length prefix, and the serializer emits the canonical one-octet zero prefix. The regression coverage also checks the extended zero form and verifies that parsed empty values can be serialized.

### Contract and impact

[RFC 7011 section 7](https://www.rfc-editor.org/rfc/rfc7011.html#section-7) defines the one-octet length form for values shorter than 255 octets, including zero. Empty values no longer disappear from decoded records or fail during re-export.

### Validation

```text
cargo test --test ipfix_zero_length_varlen
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All checks pass on the PR branch.