### PR TITLE
fix: decode reduced unsigned IPFIX values

### DIFF
--- a/src/variable_versions/field_value.rs
+++ b/src/variable_versions/field_value.rs
@@ -379,6 +379,13 @@ impl DataNumber {
             (3, true) => parse_i24_be(i).map(|(i, j)| (i, Self::I24(j))),
             (4, true) => parse_i32_be(i).map(|(i, j)| (i, Self::I32(j))),
             (4, false) => parse_u32_be(i).map(|(i, j)| (i, Self::U32(j))),
+            (5..=7, false) => {
+                let (i, bytes) = take(field_length)(i)?;
+                let mut value = [0u8; 8];
+                let start = value.len() - usize::from(field_length);
+                value[start..].copy_from_slice(bytes);
+                Ok((i, Self::U64(u64::from_be_bytes(value))))
+            }
             (8, false) => parse_u64_be(i).map(|(i, j)| (i, Self::U64(j))),
             (8, true) => parse_i64_be(i).map(|(i, j)| (i, Self::I64(j))),
             (16, false) => parse_u128_be(i).map(|(i, j)| (i, Self::U128(j))),

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -4,6 +4,7 @@
 //! Parsing impl blocks for IPFIX types (FlowSetBody, FieldParser, TemplateField, etc.)
 //! are also defined here.
 
+use super::types::serialization_field_lengths;
 use super::{
     CommonTemplate, DATA_TEMPLATE_IPFIX_ID, DEFAULT_MAX_TEMPLATE_CACHE_SIZE, Data, FieldParser,
     FlowSet, FlowSetBody, FlowSetHeader, IPFix, IPFixFieldPair, IPFixParser, MAX_FIELD_COUNT,
@@ -1723,15 +1724,6 @@ impl OptionsTemplate {
     }
 }
 
-/// Collect template field lengths only when at least one field is variable-length.
-fn collect_varlen_field_lengths(fields: &[TemplateField]) -> Vec<u16> {
-    if fields.iter().any(|f| f.field_length == 65535) {
-        fields.iter().map(|f| f.field_length).collect()
-    } else {
-        Vec::new()
-    }
-}
-
 impl Data {
     pub(super) fn parse_with_registry_and_budget<'a>(
         i: &'a [u8],
@@ -1740,7 +1732,6 @@ impl Data {
         max_records: usize,
         budget: &mut DecodedOutputBudget,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let (i, fields) = FieldParser::parse_with_registry_and_budget(
             i,
             template,
@@ -1748,6 +1739,8 @@ impl Data {
             max_records,
             budget,
         )?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1764,10 +1757,11 @@ impl Data {
         template: &Template,
         limits: crate::DecodedOutputLimits,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let mut budget = limits.budget();
         let (i, fields) =
             FieldParser::parse_with_budget(i, template, limits.max_records(), &mut budget)?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1787,7 +1781,6 @@ impl OptionsData {
         max_records: usize,
         budget: &mut DecodedOutputBudget,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let (i, fields) = FieldParser::parse_with_registry_and_budget(
             i,
             template,
@@ -1795,6 +1788,8 @@ impl OptionsData {
             max_records,
             budget,
         )?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1811,10 +1806,11 @@ impl OptionsData {
         template: &OptionsTemplate,
         limits: crate::DecodedOutputLimits,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let mut budget = limits.budget();
         let (i, fields) =
             FieldParser::parse_with_budget(i, template, limits.max_records(), &mut budget)?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {

--- a/src/variable_versions/ipfix/serializer.rs
+++ b/src/variable_versions/ipfix/serializer.rs
@@ -3,6 +3,7 @@
 //! Type definitions live in the parent `ipfix` module (`mod.rs`).
 
 use super::{FlowSetBody, IPFix, TemplateField, calculate_padding};
+use crate::variable_versions::field_value::{DataNumber, FieldValue};
 use crate::variable_versions::v9::ScopeDataField as V9ScopeDataField;
 
 /// Write an RFC 7011 Section 7 variable-length encoding prefix.
@@ -59,7 +60,20 @@ fn serialize_data_fields(
             if is_varlen {
                 write_varlen_prefix(result, v.byte_len())?;
             }
-            v.write_be_bytes(result)?;
+            match (v, template_field_lengths.get(idx).copied()) {
+                (FieldValue::DataNumber(DataNumber::U64(value)), Some(width @ 5..=7)) => {
+                    let bytes = value.to_be_bytes();
+                    let start = bytes.len() - usize::from(width);
+                    if bytes[..start].iter().any(|byte| *byte != 0) {
+                        return Err(format!(
+                            "unsigned value {value} does not fit in {width} octets"
+                        )
+                        .into());
+                    }
+                    result.extend_from_slice(&bytes[start..]);
+                }
+                _ => v.write_be_bytes(result)?,
+            }
         }
     }
     Ok(())

--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -157,6 +157,30 @@ pub struct FlowSetHeader {
     pub length: u16,
 }
 
+pub(super) fn serialization_field_lengths<K>(
+    template_fields: &[TemplateField],
+    records: &[Vec<(K, FieldValue)>],
+) -> Vec<u16> {
+    let needs_metadata = template_fields
+        .iter()
+        .any(|field| field.field_length == u16::MAX)
+        || records.iter().any(|record| {
+            record
+                .iter()
+                .zip(template_fields)
+                .any(|((_, value), field)| value.byte_len() != usize::from(field.field_length))
+        });
+
+    if needs_metadata {
+        template_fields
+            .iter()
+            .map(|field| field.field_length)
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
 /// Parsed IPFIX data records decoded using an IPFIX template.
 #[derive(Debug, Clone, Serialize, Nom)]
 #[nom(ExtraArgs(template: &Template))]
@@ -168,19 +192,12 @@ pub struct Data {
     pub fields: Vec<IPFixFlowRecord>,
     #[serde(skip_serializing)]
     pub padding: Vec<u8>,
-    /// Original template field lengths, used to emit RFC 7011 variable-length
-    /// prefixes during serialization.  Not included in equality comparisons.
-    /// Only populated when the template contains variable-length fields
-    /// (field_length == 65535) to avoid unnecessary allocations.
+    /// Original template field lengths needed for lossless serialization.
+    /// Not included in equality comparisons. Populated only when a template
+    /// contains variable-length fields or a decoded value has a different
+    /// in-memory width than its wire field.
     #[serde(skip_serializing)]
-    #[nom(Value({
-        let fields = template.get_fields();
-        if fields.iter().any(|f| f.field_length == 65535) {
-            fields.iter().map(|f| f.field_length).collect::<Vec<u16>>()
-        } else {
-            Vec::new()
-        }
-    }))]
+    #[nom(Value(serialization_field_lengths(template.get_fields(), &fields)))]
     pub(crate) template_field_lengths: Vec<u16>,
 }
 
@@ -195,9 +212,9 @@ impl Data {
     ///
     /// The resulting `Data` has no template field length metadata, so
     /// serialization via [`IPFix::to_be_bytes()`]
-    /// assumes all fields are fixed-length.  Use
-    /// [`Data::with_template_field_lengths`] when the template contains
-    /// variable-length fields (field_length == 65535).
+    /// assumes all fields use their value's natural fixed width. Use
+    /// [`Data::with_template_field_lengths`] when the template contains a
+    /// variable-length field or a different fixed wire width.
     pub fn new(fields: Vec<IPFixFlowRecord>) -> Self {
         debug_assert!(
             !fields.iter().any(|record| record
@@ -215,13 +232,14 @@ impl Data {
 
     /// Returns `true` if this data record has variable-length field metadata.
     pub fn has_varlen_metadata(&self) -> bool {
-        !self.template_field_lengths.is_empty()
+        self.template_field_lengths.contains(&u16::MAX)
     }
 
     /// Creates a new Data instance with explicit template field lengths.
     ///
     /// Required for correct round-trip serialization when the template
-    /// contains variable-length fields (RFC 7011, field_length == 65535).
+    /// contains variable-length fields (RFC 7011, field_length == 65535) or
+    /// fixed widths that differ from the decoded value's in-memory width.
     /// Each entry in `template_field_lengths` corresponds to the template
     /// field at the same index; entries with value 65535 cause an RFC 7011
     /// variable-length prefix to be emitted during serialization.
@@ -263,18 +281,12 @@ pub struct OptionsData {
     pub fields: Vec<Vec<IPFixFieldPair>>,
     #[serde(skip_serializing)]
     pub padding: Vec<u8>,
-    /// Original template field lengths, used to emit RFC 7011 variable-length
-    /// prefixes during serialization.  Not included in equality comparisons.
-    /// Only populated when the template contains variable-length fields.
+    /// Original template field lengths needed for lossless serialization.
+    /// Not included in equality comparisons. Populated only when a template
+    /// contains variable-length fields or a decoded value has a different
+    /// in-memory width than its wire field.
     #[serde(skip_serializing)]
-    #[nom(Value({
-        let fields = template.get_fields();
-        if fields.iter().any(|f| f.field_length == 65535) {
-            fields.iter().map(|f| f.field_length).collect::<Vec<u16>>()
-        } else {
-            Vec::new()
-        }
-    }))]
+    #[nom(Value(serialization_field_lengths(template.get_fields(), &fields)))]
     pub(crate) template_field_lengths: Vec<u16>,
 }
 

--- a/tests/ipfix_reduced_unsigned.rs
+++ b/tests/ipfix_reduced_unsigned.rs
@@ -1,0 +1,38 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn five_octet_reduced_unsigned_value_is_decoded() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&5u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &[0x80, 0, 0, 0, 5]));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert_eq!(data.fields[0][0].1.as_u64(), Some(0x80_0000_0005));
+}

--- a/tests/ipfix_reduced_unsigned.rs
+++ b/tests/ipfix_reduced_unsigned.rs
@@ -17,22 +17,35 @@ fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
 
 #[test]
 fn five_octet_reduced_unsigned_value_is_decoded() {
-    let mut template = Vec::new();
-    template.extend_from_slice(&256u16.to_be_bytes());
-    template.extend_from_slice(&1u16.to_be_bytes());
-    template.extend_from_slice(&1u16.to_be_bytes());
-    template.extend_from_slice(&5u16.to_be_bytes());
+    for (field_value, expected) in [
+        (&[0x80, 0, 0, 0, 5][..], 0x80_0000_0005),
+        (&[0x80, 0, 0, 0, 0, 5][..], 0x8000_0000_0005),
+        (&[0x80, 0, 0, 0, 0, 0, 5][..], 0x80_0000_0000_0005),
+    ] {
+        let mut template = Vec::new();
+        template.extend_from_slice(&256u16.to_be_bytes());
+        template.extend_from_slice(&1u16.to_be_bytes());
+        template.extend_from_slice(&1u16.to_be_bytes());
+        template.extend_from_slice(&u16::try_from(field_value.len()).unwrap().to_be_bytes());
 
-    let mut parser = NetflowParser::default();
-    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+        let mut parser = NetflowParser::default();
+        assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
 
-    let decoded = parser.parse_bytes(&message_with_set(256, &[0x80, 0, 0, 0, 5]));
-    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
-    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
-        panic!("expected IPFIX packet");
-    };
-    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
-        panic!("expected IPFIX data");
-    };
-    assert_eq!(data.fields[0][0].1.as_u64(), Some(0x80_0000_0005));
+        let decoded = parser.parse_bytes(&message_with_set(256, field_value));
+        assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+        let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+            panic!("expected IPFIX packet");
+        };
+        let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+            panic!("expected IPFIX data");
+        };
+        assert_eq!(data.fields[0][0].1.as_u64(), Some(expected));
+
+        let mut canonical_body = field_value.to_vec();
+        canonical_body.resize(8, 0);
+        assert_eq!(
+            packet.to_be_bytes().unwrap(),
+            message_with_set(256, &canonical_body)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

This two-commit draft keeps the synthetic failing reproducer as commit 1 and adds a bounded decoder/round-trip fix as commit 2.

- Decode five-, six-, and seven-octet unsigned values into the existing `U64` representation.
- Retain private Template-width metadata only when lossless serialization needs it, preserving the existing fast path for ordinary fixed-width records.
- Re-emit the declared reduced width and reject a programmatically supplied value that does not fit rather than silently truncating it.
- Cover all three reduced widths and their canonical padded round trips.

## Root cause

The shared numeric decoder recognized unsigned values of one, two, three, four, eight, and sixteen octets. Five- through seven-octet `unsigned64` values fell through to opaque bytes. Simply decoding them as `U64` would then expand them to eight octets on export, because parsed Data retained Template widths only for variable-length fields.

## Contract and impact

[RFC 7011 section 6.2](https://www.rfc-editor.org/rfc/rfc7011.html#section-6.2) permits reduced-size encoding of unsigned integer Information Elements, including five-, six-, and seven-octet encodings of `unsigned64`.

Exporters can legitimately reduce counter widths. Returning opaque bytes prevents downstream aggregation and thresholding; expanding the width during re-export would alter record boundaries. This change preserves both numeric interpretation and the received wire width without adding a public value variant or API.

## Validation

```text
cargo test --test ipfix_reduced_unsigned five_octet_reduced_unsigned_value_is_decoded -- --exact
cargo test --test round_trip test_ipfix_fixed_only_template_no_varlen_overhead -- --exact
cargo test --test round_trip test_ipfix_mixed_fixed_and_varlen_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All passed locally on this branch. The PR remains a draft for maintainer review.