### PR TITLE
fix: decode reduced IPFIX float64 values

### DIFF
--- a/src/variable_versions/field_value.rs
+++ b/src/variable_versions/field_value.rs
@@ -973,6 +973,11 @@ impl FieldValue {
                 let (i, f) = f64::parse(remaining)?;
                 (i, FieldValue::Float64(f))
             }
+            FieldDataType::Float64 if field_length == 4 => {
+                let (i, bytes) = take(4u16)(remaining)?;
+                let f = f32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                (i, FieldValue::Float64(f64::from(f)))
+            }
             // Fall back to raw bytes for typed fields with unexpected length
             FieldDataType::ProtocolType
             | FieldDataType::ForwardingStatus

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -4,6 +4,7 @@
 //! Parsing impl blocks for IPFIX types (FlowSetBody, FieldParser, TemplateField, etc.)
 //! are also defined here.
 
+use super::types::serialization_field_lengths;
 use super::{
     CommonTemplate, DATA_TEMPLATE_IPFIX_ID, DEFAULT_MAX_TEMPLATE_CACHE_SIZE, Data, FieldParser,
     FlowSet, FlowSetBody, FlowSetHeader, IPFix, IPFixFieldPair, IPFixParser, MAX_FIELD_COUNT,
@@ -1723,15 +1724,6 @@ impl OptionsTemplate {
     }
 }
 
-/// Collect template field lengths only when at least one field is variable-length.
-fn collect_varlen_field_lengths(fields: &[TemplateField]) -> Vec<u16> {
-    if fields.iter().any(|f| f.field_length == 65535) {
-        fields.iter().map(|f| f.field_length).collect()
-    } else {
-        Vec::new()
-    }
-}
-
 impl Data {
     pub(super) fn parse_with_registry_and_budget<'a>(
         i: &'a [u8],
@@ -1740,7 +1732,6 @@ impl Data {
         max_records: usize,
         budget: &mut DecodedOutputBudget,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let (i, fields) = FieldParser::parse_with_registry_and_budget(
             i,
             template,
@@ -1748,6 +1739,8 @@ impl Data {
             max_records,
             budget,
         )?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1764,10 +1757,11 @@ impl Data {
         template: &Template,
         limits: crate::DecodedOutputLimits,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let mut budget = limits.budget();
         let (i, fields) =
             FieldParser::parse_with_budget(i, template, limits.max_records(), &mut budget)?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1787,7 +1781,6 @@ impl OptionsData {
         max_records: usize,
         budget: &mut DecodedOutputBudget,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let (i, fields) = FieldParser::parse_with_registry_and_budget(
             i,
             template,
@@ -1795,6 +1788,8 @@ impl OptionsData {
             max_records,
             budget,
         )?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {
@@ -1811,10 +1806,11 @@ impl OptionsData {
         template: &OptionsTemplate,
         limits: crate::DecodedOutputLimits,
     ) -> IResult<&'a [u8], Self> {
-        let template_field_lengths = collect_varlen_field_lengths(template.get_fields());
         let mut budget = limits.budget();
         let (i, fields) =
             FieldParser::parse_with_budget(i, template, limits.max_records(), &mut budget)?;
+        let template_field_lengths =
+            serialization_field_lengths(template.get_fields(), &fields);
         Ok((
             i,
             Self {

--- a/src/variable_versions/ipfix/serializer.rs
+++ b/src/variable_versions/ipfix/serializer.rs
@@ -3,6 +3,7 @@
 //! Type definitions live in the parent `ipfix` module (`mod.rs`).
 
 use super::{FlowSetBody, IPFix, TemplateField, calculate_padding};
+use crate::variable_versions::field_value::FieldValue;
 use crate::variable_versions::v9::ScopeDataField as V9ScopeDataField;
 
 /// Write an RFC 7011 Section 7 variable-length encoding prefix.
@@ -59,7 +60,12 @@ fn serialize_data_fields(
             if is_varlen {
                 write_varlen_prefix(result, v.byte_len())?;
             }
-            v.write_be_bytes(result)?;
+            match (v, template_field_lengths.get(idx).copied()) {
+                (FieldValue::Float64(value), Some(4)) => {
+                    result.extend_from_slice(&(*value as f32).to_be_bytes());
+                }
+                _ => v.write_be_bytes(result)?,
+            }
         }
     }
     Ok(())

--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -157,6 +157,30 @@ pub struct FlowSetHeader {
     pub length: u16,
 }
 
+pub(super) fn serialization_field_lengths<K>(
+    template_fields: &[TemplateField],
+    records: &[Vec<(K, FieldValue)>],
+) -> Vec<u16> {
+    let needs_metadata = template_fields
+        .iter()
+        .any(|field| field.field_length == u16::MAX)
+        || records.iter().any(|record| {
+            record
+                .iter()
+                .zip(template_fields)
+                .any(|((_, value), field)| value.byte_len() != usize::from(field.field_length))
+        });
+
+    if needs_metadata {
+        template_fields
+            .iter()
+            .map(|field| field.field_length)
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
+
 /// Parsed IPFIX data records decoded using an IPFIX template.
 #[derive(Debug, Clone, Serialize, Nom)]
 #[nom(ExtraArgs(template: &Template))]
@@ -168,19 +192,12 @@ pub struct Data {
     pub fields: Vec<IPFixFlowRecord>,
     #[serde(skip_serializing)]
     pub padding: Vec<u8>,
-    /// Original template field lengths, used to emit RFC 7011 variable-length
-    /// prefixes during serialization.  Not included in equality comparisons.
-    /// Only populated when the template contains variable-length fields
-    /// (field_length == 65535) to avoid unnecessary allocations.
+    /// Original template field lengths needed for lossless serialization.
+    /// Not included in equality comparisons. Populated only when a template
+    /// contains variable-length fields or a decoded value has a different
+    /// in-memory width than its wire field.
     #[serde(skip_serializing)]
-    #[nom(Value({
-        let fields = template.get_fields();
-        if fields.iter().any(|f| f.field_length == 65535) {
-            fields.iter().map(|f| f.field_length).collect::<Vec<u16>>()
-        } else {
-            Vec::new()
-        }
-    }))]
+    #[nom(Value(serialization_field_lengths(template.get_fields(), &fields)))]
     pub(crate) template_field_lengths: Vec<u16>,
 }
 
@@ -195,9 +212,9 @@ impl Data {
     ///
     /// The resulting `Data` has no template field length metadata, so
     /// serialization via [`IPFix::to_be_bytes()`]
-    /// assumes all fields are fixed-length.  Use
-    /// [`Data::with_template_field_lengths`] when the template contains
-    /// variable-length fields (field_length == 65535).
+    /// assumes all fields use their value's natural fixed width. Use
+    /// [`Data::with_template_field_lengths`] when the template contains a
+    /// variable-length field or a different fixed wire width.
     pub fn new(fields: Vec<IPFixFlowRecord>) -> Self {
         debug_assert!(
             !fields.iter().any(|record| record
@@ -215,13 +232,14 @@ impl Data {
 
     /// Returns `true` if this data record has variable-length field metadata.
     pub fn has_varlen_metadata(&self) -> bool {
-        !self.template_field_lengths.is_empty()
+        self.template_field_lengths.contains(&u16::MAX)
     }
 
     /// Creates a new Data instance with explicit template field lengths.
     ///
     /// Required for correct round-trip serialization when the template
-    /// contains variable-length fields (RFC 7011, field_length == 65535).
+    /// contains variable-length fields (RFC 7011, field_length == 65535) or
+    /// fixed widths that differ from the decoded value's in-memory width.
     /// Each entry in `template_field_lengths` corresponds to the template
     /// field at the same index; entries with value 65535 cause an RFC 7011
     /// variable-length prefix to be emitted during serialization.
@@ -263,18 +281,12 @@ pub struct OptionsData {
     pub fields: Vec<Vec<IPFixFieldPair>>,
     #[serde(skip_serializing)]
     pub padding: Vec<u8>,
-    /// Original template field lengths, used to emit RFC 7011 variable-length
-    /// prefixes during serialization.  Not included in equality comparisons.
-    /// Only populated when the template contains variable-length fields.
+    /// Original template field lengths needed for lossless serialization.
+    /// Not included in equality comparisons. Populated only when a template
+    /// contains variable-length fields or a decoded value has a different
+    /// in-memory width than its wire field.
     #[serde(skip_serializing)]
-    #[nom(Value({
-        let fields = template.get_fields();
-        if fields.iter().any(|f| f.field_length == 65535) {
-            fields.iter().map(|f| f.field_length).collect::<Vec<u16>>()
-        } else {
-            Vec::new()
-        }
-    }))]
+    #[nom(Value(serialization_field_lengths(template.get_fields(), &fields)))]
     pub(crate) template_field_lengths: Vec<u16>,
 }
 

--- a/tests/ipfix_reduced_float.rs
+++ b/tests/ipfix_reduced_float.rs
@@ -1,0 +1,42 @@
+use netflow_parser::variable_versions::field_value::FieldValue;
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn four_octet_reduced_float64_value_is_decoded() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&311u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &1.5f32.to_be_bytes()));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert!(matches!(
+        data.fields[0][0].1,
+        FieldValue::Float64(value) if value == 1.5
+    ));
+}

--- a/tests/ipfix_reduced_float.rs
+++ b/tests/ipfix_reduced_float.rs
@@ -39,4 +39,8 @@ fn four_octet_reduced_float64_value_is_decoded() {
         data.fields[0][0].1,
         FieldValue::Float64(value) if value == 1.5
     ));
+    assert_eq!(
+        packet.to_be_bytes().unwrap(),
+        message_with_set(256, &1.5f32.to_be_bytes())
+    );
 }


### PR DESCRIPTION
## Summary

This two-commit draft keeps the synthetic failing reproducer as commit 1 and adds a bounded decoder/round-trip fix as commit 2.

- Decode a four-octet reduced `float64` field from its IEEE 754 `float32` wire representation into the existing `Float64(f64)` value.
- Retain private Template-width metadata only when lossless serialization needs it, preserving the existing fast path for ordinary fixed-width records.
- Re-emit four bytes when the parsed Template declared reduced encoding.
- Add an exact round-trip assertion without adding a public value variant or API.

## Root cause

The shared typed decoder accepted `float64` only at eight octets and sent a standards-defined four-octet reduced encoding to the opaque-byte fallback. Decoding it into the existing eight-byte in-memory value alone would expand it during re-export, because parsed Data previously retained Template widths only for variable-length fields.

## Contract and impact

[RFC 7011 section 6.2](https://www.rfc-editor.org/rfc/rfc7011.html#section-6.2) specifically permits a `float64` Information Element to use four-octet `float32` reduced encoding. The [IANA IPFIX registry](https://www.iana.org/assignments/ipfix/ipfix.xhtml) defines IE 311 as `float64`.

Treating the value as opaque prevents downstream consumers from applying an exported sampling probability to measured traffic. Expanding it on re-export would alter record boundaries; the private width metadata preserves the declared representation.

## Validation

```text
cargo test --test ipfix_reduced_float four_octet_reduced_float64_value_is_decoded -- --exact
cargo test --test round_trip test_ipfix_fixed_only_template_no_varlen_overhead -- --exact
cargo test --test round_trip test_ipfix_mixed_fixed_and_varlen_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All passed locally on this branch. The PR remains a draft for maintainer review.