### PR TITLE
fix: decode reduced forwarding status values

### DIFF
--- a/src/variable_versions/field_value.rs
+++ b/src/variable_versions/field_value.rs
@@ -914,6 +914,10 @@ impl FieldValue {
                 let (i, status) = ForwardingStatus::parse(remaining)?;
                 (i, FieldValue::ForwardingStatus(status))
             }
+            FieldDataType::ForwardingStatus if matches!(field_length, 2..=4) => {
+                let (i, status) = DataNumber::parse(remaining, field_length, false)?;
+                (i, FieldValue::DataNumber(status))
+            }
             FieldDataType::FragmentFlags if field_length == 1 => {
                 let (i, flags) = FragmentFlags::parse(remaining)?;
                 (i, FieldValue::FragmentFlags(flags))

--- a/tests/ipfix_specialized_reduced.rs
+++ b/tests/ipfix_specialized_reduced.rs
@@ -17,22 +17,28 @@ fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
 
 #[test]
 fn reduced_forwarding_status_is_decoded_as_an_unsigned_value() {
-    let mut template = Vec::new();
-    template.extend_from_slice(&256u16.to_be_bytes());
-    template.extend_from_slice(&1u16.to_be_bytes());
-    template.extend_from_slice(&89u16.to_be_bytes());
-    template.extend_from_slice(&2u16.to_be_bytes());
+    for (field_length, field_value) in [
+        (2u16, &[0, 1][..]),
+        (3, &[0, 0, 1][..]),
+        (4, &[0, 0, 0, 1][..]),
+    ] {
+        let mut template = Vec::new();
+        template.extend_from_slice(&256u16.to_be_bytes());
+        template.extend_from_slice(&1u16.to_be_bytes());
+        template.extend_from_slice(&89u16.to_be_bytes());
+        template.extend_from_slice(&field_length.to_be_bytes());
 
-    let mut parser = NetflowParser::default();
-    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+        let mut parser = NetflowParser::default();
+        assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
 
-    let decoded = parser.parse_bytes(&message_with_set(256, &[0, 1]));
-    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
-    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
-        panic!("expected IPFIX packet");
-    };
-    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
-        panic!("expected IPFIX data");
-    };
-    assert_eq!(data.fields[0][0].1.as_u64(), Some(1));
+        let decoded = parser.parse_bytes(&message_with_set(256, field_value));
+        assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+        let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+            panic!("expected IPFIX packet");
+        };
+        let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+            panic!("expected IPFIX data");
+        };
+        assert_eq!(data.fields[0][0].1.as_u64(), Some(1));
+    }
 }

--- a/tests/ipfix_specialized_reduced.rs
+++ b/tests/ipfix_specialized_reduced.rs
@@ -1,0 +1,38 @@
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn reduced_forwarding_status_is_decoded_as_an_unsigned_value() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&89u16.to_be_bytes());
+    template.extend_from_slice(&2u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+
+    let decoded = parser.parse_bytes(&message_with_set(256, &[0, 1]));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert_eq!(data.fields[0][0].1.as_u64(), Some(1));
+}


### PR DESCRIPTION
## Summary

This two-commit draft keeps the synthetic failing reproducer as commit 1 and adds a surgical decoder fix as commit 2.

- Preserve the specialized `ForwardingStatus` representation for the canonical one-octet encoding.
- Decode valid two-, three-, and four-octet encodings through the existing unsigned `DataNumber` representations.
- Extend the integration coverage across every remaining legal reduced width.

## Root cause

IE 89 is mapped to the specialized `ForwardingStatus` field type. The shared field decoder handled only its one-octet form and sent every other width to the opaque-byte fallback, bypassing the IE's registered `unsigned32` abstract type.

## Contract and impact

[RFC 7011 section 6.2](https://www.rfc-editor.org/rfc/rfc7011.html#section-6.2) permits reduced-size encoding of unsigned integer Information Elements, and the [IANA IPFIX registry](https://www.iana.org/assignments/ipfix/ipfix.xhtml) defines IE 89 as `unsigned32`.

Returning opaque bytes prevents consumers from interpreting standards-compliant forwarding-status values. The width-matched `U16`, `U24`, and `U32` variants also retain the received width when serialized, without adding a public type or API.

## Validation

```text
cargo test --test ipfix_specialized_reduced reduced_forwarding_status_is_decoded_as_an_unsigned_value -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All passed locally on this branch. The PR remains a draft for maintainer review.