### PR TITLE
fix: decode IPFIX IE 266 as opaque octets

### DIFF
--- a/src/variable_versions/ipfix/lookup.rs
+++ b/src/variable_versions/ipfix/lookup.rs
@@ -906,7 +906,7 @@ ipfix_field_enum! {
     ReverseMessageScope = 263 => FieldDataType::UnsignedDataNumber,
     ReverseMinExportSeconds = 264 => FieldDataType::DurationSeconds,
     ReverseMinFlowStartSeconds = 265 => FieldDataType::DurationSeconds,
-    ReverseOpaqueOctets = 266 => FieldDataType::String,
+    ReverseOpaqueOctets = 266 => FieldDataType::Vec,
     ReverseSessionScope = 267 => FieldDataType::UnsignedDataNumber,
     ReverseMaxFlowEndMicroseconds = 268 => FieldDataType::DurationMicrosNTP,
     ReverseMaxFlowEndMilliseconds = 269 => FieldDataType::DurationMillis,
@@ -1377,7 +1377,7 @@ MessageMd5checksum = 262 => FieldDataType::Vec,
 MessageScope = 263 => FieldDataType::UnsignedDataNumber,
 MinExportSeconds = 264 => FieldDataType::DurationSeconds,
 MinFlowStartSeconds = 265 => FieldDataType::DurationSeconds,
-OpaqueOctets = 266 => FieldDataType::String,
+OpaqueOctets = 266 => FieldDataType::Vec,
 SessionScope = 267 => FieldDataType::UnsignedDataNumber,
 MaxFlowEndMicroseconds = 268 => FieldDataType::DurationMicrosNTP,
 MaxFlowEndMilliseconds = 269 => FieldDataType::DurationMillis,
@@ -1623,7 +1623,7 @@ mod ipfix_lookup_tests {
 
     use crate::variable_versions::field_value::FieldDataType;
 
-    use super::IANAIPFixField;
+    use super::{IANAIPFixField, IPFixField, REVERSE_INFO_ENTERPRISE_NUMBER};
 
     use insta::assert_yaml_snapshot;
 
@@ -1647,5 +1647,9 @@ mod ipfix_lookup_tests {
         }
 
         assert_yaml_snapshot!(lookup);
+        assert_eq!(
+            FieldDataType::from(IPFixField::new(266, Some(REVERSE_INFO_ENTERPRISE_NUMBER))),
+            FieldDataType::Vec
+        );
     }
 }

--- a/src/variable_versions/ipfix/snapshots/netflow_parser__variable_versions__ipfix__lookup__ipfix_lookup_tests__it_tests_field_data_type_lookup.snap
+++ b/src/variable_versions/ipfix/snapshots/netflow_parser__variable_versions__ipfix__lookup__ipfix_lookup_tests__it_tests_field_data_type_lookup.snap
@@ -268,7 +268,7 @@ expression: lookup
 - UnsignedDataNumber
 - DurationSeconds
 - DurationSeconds
-- String
+- Vec
 - UnsignedDataNumber
 - DurationMicrosNTP
 - DurationMillis

--- a/tests/ipfix_ie266_octets.rs
+++ b/tests/ipfix_ie266_octets.rs
@@ -1,0 +1,45 @@
+use netflow_parser::variable_versions::field_value::FieldValue;
+use netflow_parser::variable_versions::ipfix::FlowSetBody;
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn variable_length_ie266_is_decoded_as_opaque_octets() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&266u16.to_be_bytes());
+    template.extend_from_slice(&u16::MAX.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+
+    let value = vec![0x5a; 300];
+    let mut wire = vec![255, 1, 44];
+    wire.extend_from_slice(&value);
+    let decoded = parser.parse_bytes(&message_with_set(256, &wire));
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected IPFIX data");
+    };
+    assert!(matches!(
+        &data.fields[0][0].1,
+        FieldValue::Vec(parsed) if parsed == &value
+    ));
+}


### PR DESCRIPTION
## Fix after the reproducer

This draft keeps the synthetic regression test as its first commit and adds a separate surgical fix commit.

### Root cause

The generated IANA mappings classified IE 266 (`opaqueOctets`) and its RFC 5103 reverse Information Element as `String`, even though their registered abstract type is `octetArray`.

### Fix

Both mappings now use the existing opaque `Vec` field type. The lookup snapshot is updated, and a focused unit assertion covers the reverse-enterprise mapping so the paired correction cannot silently regress.

### Contract and impact

The live [IANA IPFIX registry](https://www.iana.org/assignments/ipfix/ipfix.xhtml) defines IE 266 as `opaqueOctets` with abstract type `octetArray`, not `string`. Arbitrary bytes now remain typed as opaque data instead of inviting downstream text handling.

### Validation

```text
cargo test --test ipfix_ie266_octets variable_length_ie266_is_decoded_as_opaque_octets -- --exact
cargo test --lib variable_versions::ipfix::lookup::ipfix_lookup_tests::it_tests_field_data_type_lookup -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All checks pass on the PR branch.