### PR TITLE
fix: allow large fixed opaque IPFIX values

### DIFF
--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -199,13 +199,6 @@ impl Data {
     /// [`Data::with_template_field_lengths`] when the template contains
     /// variable-length fields (field_length == 65535).
     pub fn new(fields: Vec<IPFixFlowRecord>) -> Self {
-        debug_assert!(
-            !fields.iter().any(|record| record
-                .iter()
-                .any(|(_, v)| matches!(v, FieldValue::Vec(b) if b.len() > 254))),
-            "Data::new() should not be used with fields that may need variable-length \
-             encoding; use Data::with_template_field_lengths() instead"
-        );
         Self {
             fields,
             padding: vec![],

--- a/tests/ipfix_data_new_fixed_opaque.rs
+++ b/tests/ipfix_data_new_fixed_opaque.rs
@@ -1,0 +1,16 @@
+use netflow_parser::variable_versions::field_value::FieldValue;
+use netflow_parser::variable_versions::ipfix::lookup::IPFixField;
+use netflow_parser::variable_versions::ipfix::Data;
+
+#[test]
+fn data_new_accepts_fixed_opaque_values_larger_than_254_octets() {
+    let value = vec![0x5a; 300];
+
+    let data = Data::new(vec![vec![(
+        IPFixField::new(266, None),
+        FieldValue::Vec(value.clone()),
+    )]]);
+
+    assert_eq!(data.fields[0][0].1, FieldValue::Vec(value));
+    assert!(!data.has_varlen_metadata());
+}

--- a/tests/ipfix_data_new_fixed_opaque.rs
+++ b/tests/ipfix_data_new_fixed_opaque.rs
@@ -1,6 +1,6 @@
 use netflow_parser::variable_versions::field_value::FieldValue;
-use netflow_parser::variable_versions::ipfix::lookup::IPFixField;
 use netflow_parser::variable_versions::ipfix::Data;
+use netflow_parser::variable_versions::ipfix::lookup::IPFixField;
 
 #[test]
 fn data_new_accepts_fixed_opaque_values_larger_than_254_octets() {


### PR DESCRIPTION
## Fix after the reproducer

This draft keeps the focused public-API regression test as its first commit and adds a separate surgical fix commit.

### Root cause

`Data::new` used a value-size heuristic: any opaque `Vec` longer than 254 octets triggered a debug assertion intended to guard variable-length serialization. IPFIX variable-length status is determined by the Template's `65535` field-length marker, not by the runtime value size.

### Fix

The incorrect debug assertion is removed. The constructor's existing documented behavior remains unchanged: metadata-free fields are treated as fixed-length, while callers use `with_template_field_lengths` for Template-declared variable-length fields.

### Contract and impact

[`Data::new` documents](https://github.com/mikemiles-dev/netflow_parser/blob/main/src/variable_versions/ipfix/types.rs#L194-L200) this fixed-versus-variable distinction. Applications can now construct legitimate large fixed opaque values without a debug/test-profile panic.

### Validation

```text
cargo test --test ipfix_data_new_fixed_opaque data_new_accepts_fixed_opaque_values_larger_than_254_octets -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All checks pass on the PR branch.