### PR TITLE
fix: preserve NetFlow v9 data padding

### DIFF
--- a/src/variable_versions/v9/parser.rs
+++ b/src/variable_versions/v9/parser.rs
@@ -26,7 +26,7 @@ use crate::variable_versions::metrics::CacheMetricsInner;
 use crate::variable_versions::output_budget::PendingOutputError;
 use crate::variable_versions::template_events::TemplateProtocol;
 use crate::variable_versions::ttl::{TemplateWithTtl, TtlConfig};
-use crate::variable_versions::wire::RecordBodyKind;
+use crate::variable_versions::wire::{RecordBodyKind, is_v9_padding};
 use crate::variable_versions::{
     Config, ConfigError, DecodedOutputBudget, ParserConfig, ParserFields, PendingFlowCache,
     PendingFlowEntry, PendingFlowsConfig, PendingReplayOutcome,
@@ -813,6 +813,26 @@ impl V9Parser {
 // ---------------------------------------------------------------------------
 
 impl FlowSetBody {
+    fn parse_data<'a>(
+        i: &'a [u8],
+        parser: &mut V9Parser,
+        template: &Template,
+    ) -> IResult<&'a [u8], Data> {
+        let (remainder, mut data) = Data::parse_with_budget(
+            i,
+            template,
+            parser.max_records_per_flowset,
+            &mut parser.decoded_output_budget,
+        )?;
+        if !data.fields.is_empty()
+            && is_v9_padding(remainder.len(), usize::from(template.get_total_size()))
+        {
+            data.padding = remainder.to_vec();
+            return Ok((&[], data));
+        }
+        Ok((remainder, data))
+    }
+
     pub(super) fn parse<'a>(
         i: &'a [u8],
         parser: &mut V9Parser,
@@ -876,12 +896,7 @@ impl FlowSetBody {
                     &mut parser.metrics,
                 ) {
                     parser.metrics.record_hit();
-                    let (i, data) = Data::parse_with_budget(
-                        i,
-                        &template,
-                        parser.max_records_per_flowset,
-                        &mut parser.decoded_output_budget,
-                    )?;
+                    let (i, data) = Self::parse_data(i, parser, &template)?;
                     return Ok((i, FlowSetBody::Data(data)));
                 }
 
@@ -908,12 +923,7 @@ impl FlowSetBody {
                 // served from the hot path.
                 if let Some(template) = parser.fetch_template_from_store(id) {
                     parser.metrics.record_hit();
-                    let (i, data) = Data::parse_with_budget(
-                        i,
-                        &template,
-                        parser.max_records_per_flowset,
-                        &mut parser.decoded_output_budget,
-                    )?;
+                    let (i, data) = Self::parse_data(i, parser, &template)?;
                     return Ok((i, FlowSetBody::Data(data)));
                 }
                 if let Some(template) = parser.fetch_options_template_from_store(id) {

--- a/tests/v9_padding_roundtrip.rs
+++ b/tests/v9_padding_roundtrip.rs
@@ -1,0 +1,45 @@
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn header() -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u32.to_be_bytes());
+    packet.extend_from_slice(&2u32.to_be_bytes());
+    packet.extend_from_slice(&3u32.to_be_bytes());
+    packet.extend_from_slice(&4u32.to_be_bytes());
+    packet
+}
+
+fn append_flowset(packet: &mut Vec<u8>, id: u16, body: &[u8]) {
+    packet.extend_from_slice(&id.to_be_bytes());
+    packet.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    packet.extend_from_slice(body);
+}
+
+#[test]
+fn reexport_preserves_nonzero_data_flowset_padding() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&82u16.to_be_bytes());
+    template.extend_from_slice(&5u16.to_be_bytes());
+    let mut template_packet = header();
+    append_flowset(&mut template_packet, 0, &template);
+
+    let mut parser = NetflowParser::default();
+    let learned = parser.parse_bytes(&template_packet);
+    assert!(learned.error.is_none(), "{:#?}", learned.error);
+
+    let mut body = b"hello".to_vec();
+    body.extend_from_slice(&[0xaa, 0xbb, 0xcc]);
+    let mut wire = header();
+    append_flowset(&mut wire, 256, &body);
+    let decoded = parser.parse_bytes(&wire);
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::V9(packet) = &decoded.packets[0] else {
+        panic!("expected NetFlow v9 packet");
+    };
+
+    assert_eq!(packet.to_be_bytes().unwrap(), wire);
+}

--- a/tests/v9_padding_roundtrip.rs
+++ b/tests/v9_padding_roundtrip.rs
@@ -1,3 +1,4 @@
+use netflow_parser::variable_versions::v9::FlowSetBody;
 use netflow_parser::{NetflowPacket, NetflowParser};
 
 fn header() -> Vec<u8> {
@@ -40,6 +41,10 @@ fn reexport_preserves_nonzero_data_flowset_padding() {
     let NetflowPacket::V9(packet) = &decoded.packets[0] else {
         panic!("expected NetFlow v9 packet");
     };
+    let FlowSetBody::Data(data) = &packet.flowsets[0].body else {
+        panic!("expected NetFlow v9 data");
+    };
 
+    assert_eq!(data.padding, [0xaa, 0xbb, 0xcc]);
     assert_eq!(packet.to_be_bytes().unwrap(), wire);
 }


### PR DESCRIPTION
## Draft regression test and surgical fix

This draft keeps the synthetic failing reproducer as commit 1 and adds the focused parser correction as commit 2.

### Baseline and reproducer

`v1.0.6` and the tested `main` baseline are both `798b3d8b5acafc9257a2ec983824627c81e13f62`; the unmodified suite passes.

A NetFlow v9 Data FlowSet contains one unambiguous five-octet record followed by three accepted padding octets: `aa bb cc`. On the baseline, parsing discards the original bytes and re-export substitutes `00 00 00`.

### Root cause and fix

The Data parser returned the unparsed remainder but never copied protocol-valid padding into the existing `Data.padding` field used by the serializer.

A shared private regular-Data helper now covers both hot-cache and store-restored Templates. After at least one record decodes, it uses the existing v9 wire helper to classify a zero-to-three-byte remainder that is shorter than a complete record, then retains those exact bytes in `Data.padding`.

This intentionally does not tighten tolerant parsing: a larger malformed suffix is left to the existing caller behavior instead of being rejected or mislabeled as padding. Zero-record Data FlowSets also retain their baseline behavior on this independent branch.

### Documented contract and impact

[RFC 3954 section 5.3](https://www.rfc-editor.org/rfc/rfc3954.html#section-5.3) says padding bytes SHOULD be zero, not MUST, and the parser accepts this packet. More directly, the crate's [Re-Exporting documentation](https://github.com/mikemiles-dev/netflow_parser#re-exporting-parsed-data) promises that original padding from parsed packets is preserved exactly for byte-perfect round trips. Rewriting accepted padding breaks transparent relays, capture comparison, and downstream integrity checks over the original wire image.

### Validation

```text
cargo test --test v9_padding_roundtrip reexport_preserves_nonzero_data_flowset_padding -- --exact
cargo test --test decoded_output_limits pending_replay_preserves_valid_fixed_and_variable_padding -- --exact
cargo test --lib tests::restored_legacy_tests::it_parses_v9_no_data -- --exact
cargo test --lib tests::base_tests::v9_example_from_integration_test -- --exact
cargo test --lib tests::base_tests::v9_example_from_integration_test_2 -- --exact
cargo test --test round_trip test_v9_template_and_data_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All validations pass on commit 2. The PR remains a draft for maintainer review.