### PR TITLE
fix: preserve IPFIX options template withdrawals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1978,13 +1978,15 @@ impl NetflowParser {
                 for fs in &ipfix.flowsets {
                     match &fs.body {
                         variable_versions::ipfix::FlowSetBody::Template(t) => {
-                            self.template_hooks.trigger(&TemplateEvent::Learned {
-                                template_id: Some(t.template_id),
-                                protocol: TemplateProtocol::Ipfix,
-                            });
+                            if t.field_count > 0 {
+                                self.template_hooks.trigger(&TemplateEvent::Learned {
+                                    template_id: Some(t.template_id),
+                                    protocol: TemplateProtocol::Ipfix,
+                                });
+                            }
                         }
                         variable_versions::ipfix::FlowSetBody::Templates(ts) => {
-                            for t in ts {
+                            for t in ts.iter().filter(|t| t.field_count > 0) {
                                 self.template_hooks.trigger(&TemplateEvent::Learned {
                                     template_id: Some(t.template_id),
                                     protocol: TemplateProtocol::Ipfix,
@@ -2006,13 +2008,15 @@ impl NetflowParser {
                             }
                         }
                         variable_versions::ipfix::FlowSetBody::OptionsTemplate(t) => {
-                            self.template_hooks.trigger(&TemplateEvent::Learned {
-                                template_id: Some(t.template_id),
-                                protocol: TemplateProtocol::Ipfix,
-                            });
+                            if t.field_count > 0 {
+                                self.template_hooks.trigger(&TemplateEvent::Learned {
+                                    template_id: Some(t.template_id),
+                                    protocol: TemplateProtocol::Ipfix,
+                                });
+                            }
                         }
                         variable_versions::ipfix::FlowSetBody::OptionsTemplates(ts) => {
-                            for t in ts {
+                            for t in ts.iter().filter(|t| t.field_count > 0) {
                                 self.template_hooks.trigger(&TemplateEvent::Learned {
                                     template_id: Some(t.template_id),
                                     protocol: TemplateProtocol::Ipfix,

--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -625,10 +625,12 @@ impl IPFixParser {
                     }
                 }
                 FlowSetBody::Template(t) => {
-                    learned_template_ids.push(t.template_id);
+                    if t.field_count > 0 {
+                        learned_template_ids.push(t.template_id);
+                    }
                 }
                 FlowSetBody::Templates(ts) => {
-                    for t in ts.iter() {
+                    for t in ts.iter().filter(|t| t.field_count > 0) {
                         learned_template_ids.push(t.template_id);
                     }
                 }
@@ -641,10 +643,12 @@ impl IPFixParser {
                     }
                 }
                 FlowSetBody::OptionsTemplate(t) => {
-                    learned_template_ids.push(t.template_id);
+                    if t.field_count > 0 {
+                        learned_template_ids.push(t.template_id);
+                    }
                 }
                 FlowSetBody::OptionsTemplates(ts) => {
-                    for t in ts.iter() {
+                    for t in ts.iter().filter(|t| t.field_count > 0) {
                         learned_template_ids.push(t.template_id);
                     }
                 }
@@ -1392,7 +1396,27 @@ impl IPFixParser {
     }
 }
 
+type WithdrawTemplate = (u16, fn(&mut IPFixParser, u16));
+
 impl FlowSetBody {
+    fn parse_ipfix_options_template(i: &[u8]) -> IResult<&[u8], OptionsTemplate> {
+        let (remaining, template_id) = parse_u16_be(i)?;
+        let (remaining, field_count) = parse_u16_be(remaining)?;
+        if field_count == 0 {
+            return Ok((
+                remaining,
+                OptionsTemplate {
+                    template_id,
+                    field_count,
+                    scope_field_count: 0,
+                    fields: Vec::new(),
+                },
+            ));
+        }
+
+        OptionsTemplate::parse(i)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn parse_templates<'a, T, F>(
         i: &'a [u8],
@@ -1402,7 +1426,7 @@ impl FlowSetBody {
         multi_variant: fn(Vec<T>) -> FlowSetBody,
         validate: fn(&T, &IPFixParser) -> bool,
         add_templates: fn(&mut IPFixParser, &[T]),
-        withdraw_template: Option<fn(&mut IPFixParser, u16)>,
+        withdraw_template: Option<WithdrawTemplate>,
     ) -> IResult<&'a [u8], FlowSetBody>
     where
         T: Clone + HasTemplateId,
@@ -1410,52 +1434,35 @@ impl FlowSetBody {
     {
         let (i, templates) = many0(complete(parse_fn))(i)?;
 
-        // Handle template withdrawals (RFC 7011 Section 8.1):
-        // Templates with field_count=0 signal withdrawal from the cache.
-        // Skip withdrawal for IDs that also have a new definition in the
-        // same flowset — the new definition will simply replace the old one
-        // without needlessly draining pending flows.
-        let mut had_withdrawals = false;
-        if let Some(withdraw_fn) = withdraw_template {
-            for t in &templates {
-                if t.field_count() == 0 {
-                    let id = t.template_id();
-                    // "Withdraw all" IDs (2 for data, 3 for options) always
-                    // take effect regardless of other templates in the batch.
-                    let has_redefinition = id != DATA_TEMPLATE_IPFIX_ID
-                        && id != OPTIONS_TEMPLATE_IPFIX_ID
-                        && templates
-                            .iter()
-                            .any(|other| other.template_id() == id && other.field_count() > 0);
-                    if !has_redefinition {
-                        withdraw_fn(parser, id);
-                    }
-                    had_withdrawals = true;
+        // Definitions and withdrawals take effect in their wire order. Keep
+        // withdrawals in the parsed representation so re-export can preserve
+        // the original Template Set.
+        let mut accepted_templates = Vec::with_capacity(templates.len());
+        for template in templates {
+            if template.field_count() == 0 {
+                // Reserved IDs can be zero-valued Set padding, not withdrawals.
+                if let Some((withdraw_all_id, withdraw_fn)) = withdraw_template
+                    && (template.template_id() == withdraw_all_id
+                        || template.template_id() >= 256)
+                {
+                    withdraw_fn(parser, template.template_id());
+                    accepted_templates.push(template);
                 }
+            } else if validate(&template, parser) {
+                add_templates(parser, std::slice::from_ref(&template));
+                accepted_templates.push(template);
             }
         }
 
-        // Filter to only valid templates (withdrawals will be filtered out
-        // since they have empty fields, failing the is_valid check)
-        let valid_templates: Vec<_> = templates
-            .into_iter()
-            .filter(|t| validate(t, parser))
-            .collect();
-        if valid_templates.is_empty() {
-            // If we processed withdrawals, return Empty instead of error
-            if had_withdrawals {
-                return Ok((i, FlowSetBody::Empty));
-            }
+        if accepted_templates.is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 i,
                 nom::error::ErrorKind::Verify,
             )));
         }
-        // Pass slice to add_templates to clone only what's needed
-        add_templates(parser, &valid_templates);
-        match valid_templates.len() {
+        match accepted_templates.len() {
             1 => {
-                if let Some(template) = valid_templates.into_iter().next() {
+                if let Some(template) = accepted_templates.into_iter().next() {
                     Ok((i, single_variant(template)))
                 } else {
                     Err(nom::Err::Error(nom::error::Error::new(
@@ -1464,7 +1471,7 @@ impl FlowSetBody {
                     )))
                 }
             }
-            _ => Ok((i, multi_variant(valid_templates))),
+            _ => Ok((i, multi_variant(accepted_templates))),
         }
     }
 
@@ -1482,7 +1489,9 @@ impl FlowSetBody {
                 FlowSetBody::Templates,
                 |t: &Template, p: &IPFixParser| t.is_valid(p),
                 |parser, templates| parser.add_ipfix_templates(templates),
-                Some(|parser: &mut IPFixParser, id| parser.withdraw_ipfix_template(id)),
+                Some((DATA_TEMPLATE_IPFIX_ID, |parser: &mut IPFixParser, id| {
+                    parser.withdraw_ipfix_template(id)
+                })),
             ),
             DATA_TEMPLATE_V9_ID => Self::parse_templates(
                 i,
@@ -1531,12 +1540,14 @@ impl FlowSetBody {
             OPTIONS_TEMPLATE_IPFIX_ID => Self::parse_templates(
                 i,
                 parser,
-                OptionsTemplate::parse,
+                Self::parse_ipfix_options_template,
                 FlowSetBody::OptionsTemplate,
                 FlowSetBody::OptionsTemplates,
                 |t: &OptionsTemplate, p: &IPFixParser| t.is_valid(p),
                 |parser, templates| parser.add_ipfix_options_templates(templates),
-                Some(|parser: &mut IPFixParser, id| parser.withdraw_ipfix_options_template(id)),
+                Some((OPTIONS_TEMPLATE_IPFIX_ID, |parser: &mut IPFixParser, id| {
+                    parser.withdraw_ipfix_options_template(id);
+                })),
             ),
             // Parse Data
             _ => {

--- a/src/variable_versions/ipfix/serializer.rs
+++ b/src/variable_versions/ipfix/serializer.rs
@@ -2,7 +2,7 @@
 //!
 //! Type definitions live in the parent `ipfix` module (`mod.rs`).
 
-use super::{FlowSetBody, IPFix, TemplateField, calculate_padding};
+use super::{FlowSetBody, IPFix, OptionsTemplate, TemplateField, calculate_padding};
 use crate::variable_versions::v9::ScopeDataField as V9ScopeDataField;
 
 /// Write an RFC 7011 Section 7 variable-length encoding prefix.
@@ -80,6 +80,17 @@ impl IPFix {
         }
     }
 
+    fn write_ipfix_options_template(buf: &mut Vec<u8>, template: &OptionsTemplate) {
+        buf.extend_from_slice(&template.template_id.to_be_bytes());
+        buf.extend_from_slice(&template.field_count.to_be_bytes());
+        if template.field_count > 0 {
+            buf.extend_from_slice(&template.scope_field_count.to_be_bytes());
+            for field in &template.fields {
+                Self::write_ipfix_template_field(buf, field);
+            }
+        }
+    }
+
     /// Serialize FlowSetBody to bytes
     fn serialize_flowset_body(
         body: &FlowSetBody,
@@ -120,12 +131,7 @@ impl IPFix {
             }
             FlowSetBody::OptionsTemplate(options_template) => {
                 let mut result = Vec::new();
-                result.extend_from_slice(&options_template.template_id.to_be_bytes());
-                result.extend_from_slice(&options_template.field_count.to_be_bytes());
-                result.extend_from_slice(&options_template.scope_field_count.to_be_bytes());
-                for field in options_template.fields.iter() {
-                    Self::write_ipfix_template_field(&mut result, field);
-                }
+                Self::write_ipfix_options_template(&mut result, options_template);
                 result.extend_from_slice(calculate_padding(result.len()));
                 Ok(result)
             }
@@ -160,13 +166,8 @@ impl IPFix {
             }
             FlowSetBody::OptionsTemplates(templates) => {
                 let mut result = Vec::new();
-                for template in templates.iter() {
-                    result.extend_from_slice(&template.template_id.to_be_bytes());
-                    result.extend_from_slice(&template.field_count.to_be_bytes());
-                    result.extend_from_slice(&template.scope_field_count.to_be_bytes());
-                    for field in template.fields.iter() {
-                        Self::write_ipfix_template_field(&mut result, field);
-                    }
+                for template in templates {
+                    Self::write_ipfix_options_template(&mut result, template);
                 }
                 result.extend_from_slice(calculate_padding(result.len()));
                 Ok(result)

--- a/tests/ipfix_options_withdrawal_roundtrip.rs
+++ b/tests/ipfix_options_withdrawal_roundtrip.rs
@@ -1,0 +1,41 @@
+use netflow_parser::{NetflowPacket, NetflowParser};
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn reexport_preserves_an_options_template_withdrawal() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&149u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(3, &template)).is_ok());
+
+    let mut withdrawal = Vec::new();
+    withdrawal.extend_from_slice(&256u16.to_be_bytes());
+    withdrawal.extend_from_slice(&0u16.to_be_bytes());
+    let wire = message_with_set(3, &withdrawal);
+    let decoded = parser.parse_bytes(&wire);
+    assert!(decoded.error.is_none(), "{:#?}", decoded.error);
+    let NetflowPacket::IPFix(packet) = &decoded.packets[0] else {
+        panic!("expected IPFIX packet");
+    };
+
+    assert_eq!(packet.flowsets.len(), 1);
+    assert_eq!(packet.to_be_bytes().unwrap(), wire);
+}


### PR DESCRIPTION
## Draft regression test and surgical fix

This draft keeps the synthetic failing reproducer as commit 1 and adds the focused parser/serializer correction as commit 2.

### Baseline and reproducer

`v1.0.6` and the tested `main` baseline are both `798b3d8b5acafc9257a2ec983824627c81e13f62`; the unmodified suite passes.

The parser first learns Options Template ID 256. A subsequent Options Template Set contains the RFC withdrawal record for that ID: Template ID 256 plus Field Count 0. On the baseline, the withdrawal affects cache state but is removed from the parsed packet, so it cannot be re-exported.

### Root cause and fix

The shared Template parser processed withdrawals separately from definitions and converted withdrawal-only Sets to `Empty`. In addition, the normal derived Options Template parser requires Scope Field Count, although an Options Template Withdrawal ends after the zero Field Count. The serializer likewise always emitted Scope Field Count.

Accepted Template records are now processed once in wire order and retained in the existing zero-field AST representation. A small Options-specific parser recognizes the four-byte withdrawal before invoking the normal Options Template parser, and a shared private serializer helper omits Scope Field Count for zero-field withdrawals in both the single and batched variants.

Only the matching withdraw-all ID (`3` for Options Templates) or an individual Template ID of at least 256 is treated as a withdrawal. Reserved zero records can be Set padding and are not exposed as synthetic withdrawals. Retained withdrawals are excluded from pending replay and `Learned` events.

### Contract and impact

[RFC 7011 section 8.1](https://www.rfc-editor.org/rfc/rfc7011.html#section-8.1) defines a withdrawal as the four-octet Template ID / zero Field Count record and permits Options Template Set ID 3. The crate's [Re-Exporting documentation](https://github.com/mikemiles-dev/netflow_parser#re-exporting-parsed-data) says parsed IPFIX packets can be re-exported. Dropping a valid control record prevents a transparent collector or relay from forwarding template lifecycle state to downstream collectors.

### Validation

```text
cargo test --test ipfix_options_withdrawal_roundtrip reexport_preserves_an_options_template_withdrawal -- --exact
cargo test --test template_cache test_ipfix_withdraw_all_options_templates -- --exact
cargo test --test template_store ipfix_template_withdrawal_evicts_from_store -- --exact
cargo test --test ipfix_template_id_ownership native_individual_withdrawal_removes_v9_style_owner -- --exact
cargo test --test ipfix_template_id_ownership native_withdraw_all_removes_both_encodings_of_the_template_class -- --exact
cargo test --lib tests::base_tests::parse_ipfix_with_v9_style_template -- --exact
cargo test --lib tests::malformed_packet_tests::test_ipfix_template_withdrawal -- --exact
cargo test --test round_trip test_ipfix_options_template_and_data_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All validations pass on commit 2. The PR remains a draft for maintainer review.