### PR TITLE
fix: reject reserved NetFlow v9 template IDs

### DIFF
--- a/src/variable_versions/v9/parser.rs
+++ b/src/variable_versions/v9/parser.rs
@@ -978,6 +978,10 @@ impl Template {
         max_field_count: usize,
         max_template_total_size: usize,
     ) -> bool {
+        if self.template_id < 256 {
+            return false;
+        }
+
         // Check field count limit
         if usize::from(self.field_count) > max_field_count {
             return false;
@@ -1035,6 +1039,10 @@ impl OptionsTemplate {
         max_field_count: usize,
         max_template_total_size: usize,
     ) -> bool {
+        if self.template_id < 256 {
+            return false;
+        }
+
         // Scope and option lengths must be multiples of 4 (each field is type_id:u16 + length:u16)
         if !self.options_scope_length.is_multiple_of(4)
             || !self.options_length.is_multiple_of(4)

--- a/tests/v9_reserved_template_id.rs
+++ b/tests/v9_reserved_template_id.rs
@@ -18,3 +18,25 @@ fn template_id_255_is_rejected() {
 
     assert!(NetflowParser::default().parse_bytes(&packet).is_err());
 }
+
+#[test]
+fn options_template_id_255_is_rejected() {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u32.to_be_bytes());
+    packet.extend_from_slice(&2u32.to_be_bytes());
+    packet.extend_from_slice(&3u32.to_be_bytes());
+    packet.extend_from_slice(&4u32.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&18u16.to_be_bytes());
+    packet.extend_from_slice(&255u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+
+    assert!(NetflowParser::default().parse_bytes(&packet).is_err());
+}

--- a/tests/v9_reserved_template_id.rs
+++ b/tests/v9_reserved_template_id.rs
@@ -1,0 +1,20 @@
+use netflow_parser::NetflowParser;
+
+#[test]
+fn template_id_255_is_rejected() {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u32.to_be_bytes());
+    packet.extend_from_slice(&2u32.to_be_bytes());
+    packet.extend_from_slice(&3u32.to_be_bytes());
+    packet.extend_from_slice(&4u32.to_be_bytes());
+    packet.extend_from_slice(&0u16.to_be_bytes());
+    packet.extend_from_slice(&12u16.to_be_bytes());
+    packet.extend_from_slice(&255u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&4u16.to_be_bytes());
+
+    assert!(NetflowParser::default().parse_bytes(&packet).is_err());
+}


### PR DESCRIPTION
## Fix after the reproducer

This draft keeps the synthetic regression test as its first commit and adds a separate surgical fix commit.

### Root cause

The NetFlow v9 Template and Options Template validators checked field shapes and configured limits but never checked the Template ID itself, allowing reserved IDs below 256 to enter parser state.

### Fix

Both validators now reject Template IDs below 256 before caching. The fix commit extends coverage to the Options Template path as well as the original Template reproducer.

### Contract and impact

[RFC 3954 section 7](https://www.rfc-editor.org/rfc/rfc3954.html#section-7) reserves Template IDs 0 through 255. Rejecting invalid definitions prevents collisions between reserved FlowSet identifiers and cached data templates.

### Validation

```text
cargo test --test v9_reserved_template_id
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All checks pass on the PR branch.