### PR TITLE
fix: reject empty NetFlow v9 data FlowSets

### DIFF
--- a/src/snapshots/netflow_parser__tests__restored_legacy_tests__it_parses_v9_no_data.snap
+++ b/src/snapshots/netflow_parser__tests__restored_legacy_tests__it_parses_v9_no_data.snap
@@ -2,33 +2,4 @@
 source: src/tests.rs
 expression: "NetflowParser::default().parse_bytes(&packet).packets"
 ---
-- V9:
-    header:
-      version: 9
-      count: 2
-      sys_up_time: 2313
-      unix_secs: 66051
-      sequence_number: 1
-      source_id: 1
-    flowsets:
-      - header:
-          flowset_id: 0
-          length: 16
-        body:
-          Template:
-            templates:
-              - template_id: 258
-                field_count: 2
-                fields:
-                  - field_type_number: 1
-                    field_type: InBytes
-                    field_length: 4
-                  - field_type_number: 8
-                    field_type: Ipv4SrcAddr
-                    field_length: 4
-      - header:
-          flowset_id: 258
-          length: 4
-        body:
-          Data:
-            fields: []
+[]

--- a/src/variable_versions/v9/parser.rs
+++ b/src/variable_versions/v9/parser.rs
@@ -868,6 +868,13 @@ impl FlowSetBody {
                 Ok((i, FlowSetBody::OptionsTemplate(result)))
             }
             _ => {
+                if id > 255 && i.is_empty() {
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        i,
+                        nom::error::ErrorKind::Verify,
+                    )));
+                }
+
                 // Try regular templates
                 if let Some(template) = crate::variable_versions::get_valid_template(
                     &mut parser.templates,

--- a/src/variable_versions/v9/serializer.rs
+++ b/src/variable_versions/v9/serializer.rs
@@ -140,6 +140,9 @@ impl V9 {
                 }
                 FlowSetBody::NoTemplate(_) | FlowSetBody::Empty => continue,
             };
+            if set.header.flowset_id > 255 && body_bytes.is_empty() {
+                return Err("V9 data FlowSet must contain at least one record".into());
+            }
             // Compute flowset length from actual serialized body instead
             // of trusting set.header.length, which can be stale when
             // padding was auto-calculated or the body was modified.

--- a/tests/v9_empty_data_flowset.rs
+++ b/tests/v9_empty_data_flowset.rs
@@ -34,3 +34,11 @@ fn empty_known_template_data_flowset_is_rejected() {
     append_flowset(&mut empty_data, 256, &[]);
     assert!(parser.parse_bytes(&empty_data).is_err());
 }
+
+#[test]
+fn empty_unknown_template_data_flowset_is_rejected() {
+    let mut empty_data = header();
+    append_flowset(&mut empty_data, 257, &[]);
+
+    assert!(NetflowParser::default().parse_bytes(&empty_data).is_err());
+}

--- a/tests/v9_empty_data_flowset.rs
+++ b/tests/v9_empty_data_flowset.rs
@@ -1,0 +1,36 @@
+use netflow_parser::NetflowParser;
+
+fn header() -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.extend_from_slice(&9u16.to_be_bytes());
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&1u32.to_be_bytes());
+    packet.extend_from_slice(&2u32.to_be_bytes());
+    packet.extend_from_slice(&3u32.to_be_bytes());
+    packet.extend_from_slice(&4u32.to_be_bytes());
+    packet
+}
+
+fn append_flowset(packet: &mut Vec<u8>, id: u16, body: &[u8]) {
+    packet.extend_from_slice(&id.to_be_bytes());
+    packet.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    packet.extend_from_slice(body);
+}
+
+#[test]
+fn empty_known_template_data_flowset_is_rejected() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+    let mut template_packet = header();
+    append_flowset(&mut template_packet, 0, &template);
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&template_packet).is_ok());
+
+    let mut empty_data = header();
+    append_flowset(&mut empty_data, 256, &[]);
+    assert!(parser.parse_bytes(&empty_data).is_err());
+}

--- a/tests/v9_empty_data_flowset.rs
+++ b/tests/v9_empty_data_flowset.rs
@@ -1,4 +1,7 @@
 use netflow_parser::NetflowParser;
+use netflow_parser::variable_versions::v9::{
+    Data, FlowSet, FlowSetBody, FlowSetHeader, Header, V9,
+};
 
 fn header() -> Vec<u8> {
     let mut packet = Vec::new();
@@ -41,4 +44,27 @@ fn empty_unknown_template_data_flowset_is_rejected() {
     append_flowset(&mut empty_data, 257, &[]);
 
     assert!(NetflowParser::default().parse_bytes(&empty_data).is_err());
+}
+
+#[test]
+fn empty_data_flowset_is_not_serialized() {
+    let packet = V9 {
+        header: Header {
+            version: 9,
+            count: 1,
+            sys_up_time: 1,
+            unix_secs: 2,
+            sequence_number: 3,
+            source_id: 4,
+        },
+        flowsets: vec![FlowSet {
+            header: FlowSetHeader {
+                flowset_id: 256,
+                length: 4,
+            },
+            body: FlowSetBody::Data(Data::new(Vec::new())),
+        }],
+    };
+
+    assert!(packet.to_be_bytes().is_err());
 }


### PR DESCRIPTION
## Draft regression test and surgical fixes

This draft keeps the synthetic failing reproducer as commit 1, the parser correction as commit 2, and a focused serializer-consistency follow-up as commit 3. The third commit preserves the already published history and closes a round-trip fuzzer failure found during final CI.

### Root cause

The NetFlow v9 Data FlowSet branch looked up template state before checking whether the length-delimited body contained any bytes. A known template therefore decoded zero records successfully, while an unknown template produced an empty `NoTemplate` value.

After parsing was corrected, the serializer could still emit the same invalid four-byte Data FlowSet from an empty public data AST. The resulting bytes were rejected when the round-trip fuzzer parsed them again.

### Fix

- Data FlowSet IDs above 255 reject an empty body before cache metrics, template lookup, secondary-store access, or pending-flow handling.
- The parser correction covers both known and unknown Template IDs and updates the directly coupled legacy snapshot.
- Export rejects any Data FlowSet ID above 255 whose serialized body is empty, at the common framing boundary before bytes are emitted.
- A focused programmatic-AST assertion covers the serializer boundary.

### Contract and impact

[RFC 3954 section 5.3](https://www.rfc-editor.org/rfc/rfc3954.html#section-5.3) defines a Data FlowSet as a header followed by one or more records. Malformed exporter output can no longer appear as a successfully decoded zero-record data packet, affect cache accounting, or be generated by the public export path.

### Validation

```text
cargo test --test v9_empty_data_flowset
cargo test --lib tests::restored_legacy_tests::it_parses_v9_no_data -- --exact
cargo test --test round_trip test_v9_template_and_data_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All local checks pass on commit 3. The PR remains a draft while GitHub Actions revalidates the new head.