### PR TITLE
fix: reject empty IPFIX data Sets

### DIFF
--- a/src/variable_versions/ipfix/parser.rs
+++ b/src/variable_versions/ipfix/parser.rs
@@ -147,6 +147,7 @@ impl IPFixParser {
             template_store: config.template_store,
             template_store_scope: config.template_store_scope,
             restored_templates: Vec::new(),
+            empty_data_set_error: false,
         })
     }
 
@@ -528,7 +529,13 @@ impl IPFixParser {
         // Reset the per-parse restored-templates buffer so the next call
         // sees only what was restored during *this* packet.
         self.restored_templates.clear();
+        self.empty_data_set_error = false;
         match IPFix::parse(packet, self) {
+            Ok(_) if self.empty_data_set_error => ParsedNetflow::Error {
+                error: NetflowError::Partial {
+                    message: "IPFIX parse error: empty Data Set".to_string(),
+                },
+            },
             Ok((remaining, mut ipfix)) => {
                 self.process_pending_flows(&mut ipfix);
                 ParsedNetflow::Success {
@@ -1540,6 +1547,14 @@ impl FlowSetBody {
             ),
             // Parse Data
             _ => {
+                if id > 255 && i.is_empty() {
+                    parser.empty_data_set_error = true;
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        i,
+                        nom::error::ErrorKind::Verify,
+                    )));
+                }
+
                 // Definition installation keeps these physical caches disjoint by
                 // Template ID, so this probe order selects representation rather
                 // than resolving competing owners.

--- a/src/variable_versions/ipfix/serializer.rs
+++ b/src/variable_versions/ipfix/serializer.rs
@@ -279,6 +279,9 @@ impl IPFix {
             }
 
             let flowset_bytes = Self::serialize_flowset_body(&flow.body)?;
+            if flow.header.header_id > 255 && flowset_bytes.is_empty() {
+                return Err("IPFIX data Set must contain at least one record".into());
+            }
 
             // Compute set length from actual serialized body instead of
             // trusting flow.header.length, which can be stale when

--- a/src/variable_versions/ipfix/types.rs
+++ b/src/variable_versions/ipfix/types.rs
@@ -65,6 +65,8 @@ pub struct IPFixParser {
     /// parse. Drained after each `parse` call to fire `TemplateEvent::Restored`
     /// hooks and to drive pending-flow replay.
     pub(crate) restored_templates: Vec<(TemplateProtocol, u16)>,
+    /// Set when a Data Set has no body bytes.
+    pub(crate) empty_data_set_error: bool,
 }
 
 /// A parsed IPFIX message containing a header and a list of flowsets.

--- a/tests/decoded_output_limits.rs
+++ b/tests/decoded_output_limits.rs
@@ -125,7 +125,7 @@ fn ipfix_data(template_id: u16, body: &[u8]) -> Vec<u8> {
 }
 
 fn ipfix_replay_boundary_body() -> Vec<u8> {
-    // The replayed Set is 65,508 bytes: it fits after a 20-byte store-backed
+    // The replayed Set is 65,508 bytes: it fits after a 22-byte store-backed
     // trigger, but not after the smallest 28-byte on-wire Template message.
     let mut body = Vec::with_capacity(65_504);
     body.push(255);
@@ -755,7 +755,7 @@ fn ipfix_no_store_drops_entry_that_cannot_fit_with_template_trigger() {
 }
 
 #[test]
-fn ipfix_store_restoration_replays_at_twenty_byte_boundary() {
+fn ipfix_store_restoration_replays_with_valid_data_trigger() {
     let store = Arc::new(InMemoryTemplateStore::new());
     let mut parser = NetflowParser::builder()
         .with_template_store(store.clone())
@@ -780,7 +780,7 @@ fn ipfix_store_restoration_replays_at_twenty_byte_boundary() {
             .is_ok()
     );
 
-    let replay = parser.parse_bytes(&ipfix_message(&[ipfix_data(256, &[])]));
+    let replay = parser.parse_bytes(&ipfix_message(&[ipfix_data(256, &[1, b'y'])]));
     assert!(replay.is_ok(), "{:?}", replay.error);
     let info = parser.ipfix_cache_info();
     assert_eq!(info.pending_flow_count, 0);

--- a/tests/ipfix_empty_data_set.rs
+++ b/tests/ipfix_empty_data_set.rs
@@ -1,0 +1,29 @@
+use netflow_parser::NetflowParser;
+
+fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
+    let length = u16::try_from(20 + body.len()).unwrap();
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&length.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&3u32.to_be_bytes());
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&u16::try_from(body.len() + 4).unwrap().to_be_bytes());
+    message.extend_from_slice(body);
+    message
+}
+
+#[test]
+fn empty_known_template_data_set_is_rejected() {
+    let mut template = Vec::new();
+    template.extend_from_slice(&256u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&1u16.to_be_bytes());
+    template.extend_from_slice(&4u16.to_be_bytes());
+
+    let mut parser = NetflowParser::default();
+    assert!(parser.parse_bytes(&message_with_set(2, &template)).is_ok());
+
+    assert!(parser.parse_bytes(&message_with_set(256, &[])).is_err());
+}

--- a/tests/ipfix_empty_data_set.rs
+++ b/tests/ipfix_empty_data_set.rs
@@ -27,3 +27,12 @@ fn empty_known_template_data_set_is_rejected() {
 
     assert!(parser.parse_bytes(&message_with_set(256, &[])).is_err());
 }
+
+#[test]
+fn empty_unknown_template_data_set_is_rejected() {
+    assert!(
+        NetflowParser::default()
+            .parse_bytes(&message_with_set(257, &[]))
+            .is_err()
+    );
+}

--- a/tests/ipfix_empty_data_set.rs
+++ b/tests/ipfix_empty_data_set.rs
@@ -1,4 +1,7 @@
 use netflow_parser::NetflowParser;
+use netflow_parser::variable_versions::ipfix::{
+    Data, FlowSet, FlowSetBody, FlowSetHeader, Header, IPFix,
+};
 
 fn message_with_set(id: u16, body: &[u8]) -> Vec<u8> {
     let length = u16::try_from(20 + body.len()).unwrap();
@@ -35,4 +38,26 @@ fn empty_unknown_template_data_set_is_rejected() {
             .parse_bytes(&message_with_set(257, &[]))
             .is_err()
     );
+}
+
+#[test]
+fn empty_data_set_is_not_serialized() {
+    let packet = IPFix {
+        header: Header {
+            version: 10,
+            length: 20,
+            export_time: 1,
+            sequence_number: 2,
+            observation_domain_id: 3,
+        },
+        flowsets: vec![FlowSet {
+            header: FlowSetHeader {
+                header_id: 256,
+                length: 4,
+            },
+            body: FlowSetBody::Data(Data::new(Vec::new())),
+        }],
+    };
+
+    assert!(packet.to_be_bytes().is_err());
 }


### PR DESCRIPTION
## Draft regression test and surgical fixes

This draft keeps the synthetic failing reproducer as commit 1, the parser correction as commit 2, and a focused serializer-consistency follow-up as commit 3. The third commit preserves the already published history and closes a round-trip fuzzer failure found during final CI.

### Root cause

The IPFIX data-ID branch entered cache/store handling without first requiring any body bytes. For a known template, the record parser returned zero records; for an unknown template, the no-template path also accepted the empty body. The enclosing tolerant Set parser could otherwise convert a local rejection into an empty successful message, so this specific contract violation must be carried to the public parse result.

After parsing was corrected, the serializer could still emit the same invalid four-byte Data Set from an empty public data AST. The resulting bytes were rejected when the round-trip fuzzer parsed them again.

### Fix

- Data Set IDs above 255 reject an empty body before template-cache or template-store lookup.
- Both known and unknown Template IDs produce the same public parse error.
- Existing tolerant handling of unrelated Set parse errors is preserved through a private per-parse marker.
- The store-replay boundary test now uses a valid non-empty record while preserving its framing distinction.
- Export rejects any Data Set ID above 255 whose serialized body is empty, at the common framing boundary before bytes are emitted.
- A focused programmatic-AST assertion covers the serializer boundary.

### Contract and impact

[RFC 7011 section 3.4.3](https://www.rfc-editor.org/rfc/rfc7011.html#section-3.4.3) defines a Data Set as a header followed by one or more Data Records. Accepting or generating a four-octet Data Set hides malformed traffic, can distort accounting, and breaks parse/serialize/reparse consistency.

### Validation

```text
cargo test --test ipfix_empty_data_set
cargo test --test decoded_output_limits ipfix_store_restoration_replays_with_valid_data_trigger -- --exact
cargo test --test round_trip test_ipfix_template_and_data_round_trip -- --exact
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
git diff --check
```

All local checks pass on commit 3. The PR remains a draft while GitHub Actions revalidates the new head.