### PR TITLE
test: expose chained IPFIX domain scoping

### DIFF
--- a/tests/auto_scoped_chained_domains.rs
+++ b/tests/auto_scoped_chained_domains.rs
@@ -1,0 +1,33 @@
+use std::net::SocketAddr;
+
+use netflow_parser::AutoScopedParser;
+
+fn template_message(domain: u32, template_id: u16) -> Vec<u8> {
+    let mut message = Vec::new();
+    message.extend_from_slice(&10u16.to_be_bytes());
+    message.extend_from_slice(&28u16.to_be_bytes());
+    message.extend_from_slice(&1u32.to_be_bytes());
+    message.extend_from_slice(&2u32.to_be_bytes());
+    message.extend_from_slice(&domain.to_be_bytes());
+    message.extend_from_slice(&2u16.to_be_bytes());
+    message.extend_from_slice(&12u16.to_be_bytes());
+    message.extend_from_slice(&template_id.to_be_bytes());
+    message.extend_from_slice(&1u16.to_be_bytes());
+    message.extend_from_slice(&1u16.to_be_bytes());
+    message.extend_from_slice(&4u16.to_be_bytes());
+    message
+}
+
+#[test]
+fn chained_ipfix_messages_are_scoped_by_each_domain() {
+    let mut batch = template_message(1, 256);
+    batch.extend_from_slice(&template_message(2, 257));
+
+    let source: SocketAddr = "192.0.2.1:2055".parse().unwrap();
+    let mut parser = AutoScopedParser::new();
+    let result = parser.parse_from_source(source, &batch);
+
+    assert!(result.error.is_none(), "{:#?}", result.error);
+    assert_eq!(result.packets.len(), 2);
+    assert_eq!(parser.ipfix_source_count(), 2);
+}


### PR DESCRIPTION
## Intentionally failing test-only draft

This draft adds one synthetic documented-behavior regression test and intentionally leaves CI red. It does not propose a routing implementation.

### Baseline

`v1.0.6` and current `main` both resolve to `798b3d8b5acafc9257a2ec983824627c81e13f62`; the unmodified suite passes.

### Reproducer

One supported `parse_from_source` call receives two complete concatenated IPFIX messages from the same socket address. Their Observation Domain IDs are 1 and 2, and each defines a different Template ID.

Observed: both packets parse successfully, but `AutoScopedParser` creates only one IPFIX source.

Expected: each message is routed to its own `(source_addr, observation_domain_id)` parser, producing two IPFIX sources.

### Contract and impact

The crate documents both [multiple-version/message chaining](https://github.com/mikemiles-dev/netflow_parser#netflow-parser) and [`AutoScopedParser` IPFIX identity](https://github.com/mikemiles-dev/netflow_parser#automatic-scoping) as `(source_addr, observation_domain_id)`. [RFC 7011 section 8](https://www.rfc-editor.org/rfc/rfc7011.html#section-8) also requires collectors to handle different Observation Domains that reuse Template IDs. Routing a whole batch through its first domain mixes the second domain's templates into the wrong cache, risking cross-domain field decoding when IDs overlap.

### Exact validation

```text
cargo test --test auto_scoped_chained_domains chained_ipfix_messages_are_scoped_by_each_domain -- --exact
```

The test compiles successfully and fails on the unchanged baseline with `left: 1`, `right: 2` IPFIX sources.
### Why this remains test-only

The collection API could route each message by looping over the parser's private one-packet path, but the public iterator currently borrows one selected child parser for its full lifetime. Correct behavior across both documented APIs requires a new multi-parser iterator ownership model plus capacity eviction and synchronous removal-reporting semantics.

That is an architectural API/lifetime change, not a surgical routing condition, so this draft intentionally remains the standalone failing evidence for maintainer design and implementation.